### PR TITLE
chore: update operator version, and support oss storage, wal configure

### DIFF
--- a/charts/greptimedb-operator/Chart.yaml
+++ b/charts/greptimedb-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 kubeVersion: ">=1.18.0-0"
 description: The greptimedb-operator Helm chart for Kubernetes
 name: greptimedb-operator
-appVersion: 0.1.0-alpha.15
-version: 0.1.1-alpha.12
+appVersion: 0.1.0-alpha.16
+version: 0.1.1-alpha.13
 type: application
 home: https://github.com/GreptimeTeam/greptimedb-operator
 sources:

--- a/charts/greptimedb-operator/crds/greptimedbcluster.yaml
+++ b/charts/greptimedb-operator/crds/greptimedbcluster.yaml
@@ -2710,6 +2710,8 @@ spec:
                       storageSize:
                         pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
                         type: string
+                      walDir:
+                        type: string
                     type: object
                   template:
                     properties:
@@ -10714,9 +10716,26 @@ spec:
                 type: integer
               storage:
                 properties:
+                  cacheCapacity:
+                    type: string
+                  cachePath:
+                    type: string
                   local:
                     properties:
                       directory:
+                        type: string
+                    type: object
+                  oss:
+                    properties:
+                      bucket:
+                        type: string
+                      endpoint:
+                        type: string
+                      region:
+                        type: string
+                      root:
+                        type: string
+                      secretName:
                         type: string
                     type: object
                   s3:

--- a/charts/greptimedb-operator/values.yaml
+++ b/charts/greptimedb-operator/values.yaml
@@ -7,7 +7,7 @@ image:
   # The image pull policy for the controller
   imagePullPolicy: IfNotPresent
   # The image tag
-  tag: 0.1.0-alpha.15
+  tag: 0.1.0-alpha.16
   # The image pull secrets.
   pullSecrets: []
 
@@ -26,11 +26,11 @@ replicas: 1
 # Default resources for greptimedb operator
 resources:
   limits:
-    cpu: 500m
-    memory: 128Mi
+    cpu: 200m
+    memory: 256Mi
   requests:
-    cpu: 250m
-    memory: 64Mi
+    cpu: 100m
+    memory: 128Mi
 
 rbac:
   # install Role Based Access Control

--- a/charts/greptimedb/Chart.yaml
+++ b/charts/greptimedb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: greptimedb
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes
 type: application
-version: 0.1.1-alpha.14
+version: 0.1.1-alpha.15
 appVersion: 0.3.2

--- a/charts/greptimedb/templates/cluster.yaml
+++ b/charts/greptimedb/templates/cluster.yaml
@@ -46,6 +46,9 @@ spec:
       storageClassName: {{ .Values.datanode.storage.storageClassName }}
       storageSize: {{ .Values.datanode.storage.storageSize }}
       storageRetainPolicy: {{ .Values.datanode.storage.storageRetainPolicy }}
+      {{- if .Values.datanode.storage.walDir }}
+      walDir: {{ .Values.datanode.storage.walDir }}
+      {{- end }}
   {{- if (and .Values.prometheusMonitor (eq .Values.prometheusMonitor.enabled true ))}}
   prometheusMonitor: {{- toYaml .Values.prometheusMonitor | nindent 4 }}
   {{- end }}
@@ -67,6 +70,13 @@ spec:
     {{- else if .Values.storage.local }}
     local:
       directory: {{ .Values.storage.local.directory }}
+    {{- else if .Values.storage.oss }}
+    oss:
+      bucket: {{ .Values.storage.oss.bucket }}
+      region: {{ .Values.storage.oss.region }}
+      root: {{ .Values.storage.oss.root }}
+      secretName: {{ .Values.storage.oss.secretName }}
+      endpoint: {{ .Values.storage.oss.endpoint }}
     {{- else }}
     {}
     {{- end }}

--- a/charts/greptimedb/values.yaml
+++ b/charts/greptimedb/values.yaml
@@ -43,8 +43,8 @@ datanode:
     storageSize: 10Gi
     storageRetainPolicy: Retain
 
-#    # The wal directory of the storage, default is "/tmp/greptimedb/wal".
-#    walDir: "/tmp/greptimedb/wal"
+    # The wal directory of the storage, default is "/tmp/greptimedb/wal".
+    walDir: "/tmp/greptimedb/wal"
 
 initializer:
   registry: docker.io

--- a/charts/greptimedb/values.yaml
+++ b/charts/greptimedb/values.yaml
@@ -43,8 +43,8 @@ datanode:
     storageSize: 10Gi
     storageRetainPolicy: Retain
 
-    # The wal directory of the storage, default is "/tmp/greptimedb/wal".
-    walDir: "/tmp/greptimedb/wal"
+#    # The wal directory of the storage, default is "/tmp/greptimedb/wal".
+#    walDir: "/tmp/greptimedb/wal"
 
 initializer:
   registry: docker.io


### PR DESCRIPTION
1. update operator version 0.1.0-alpha.16
2. support greptimedb oss storage
3. datanode wal configure