### PR TITLE
feat: add 'greptimedb-cluster' chart and make 'greptimedb' chart deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ If you want to deploy the GreptimeDB cluster, you can use the following command(
 3. **Deploy GreptimeDB cluster**
 
    ```console
-   helm install mycluster greptime/greptimedb -n default --devel
+   helm install mycluster greptime/greptimedb-cluster -n default --devel
    ```
 
    If you already have the etcd cluster, you can configure the `etcdEndpoints`：
 
    ```console
-   helm install mycluster greptime/greptimedb \
+   helm install mycluster greptime/greptimedb-cluster \
    --set etcdEndpoints=etcd.default:2379 \
    -n default --devel
    ```
@@ -114,9 +114,10 @@ kubectl delete crds greptimedbclusters.greptime.io
 
 ## List of Charts
 
-- [greptimedb](./charts/greptimedb/README.md)
 - [greptimedb-operator](./charts/greptimedb-operator/README.md)
 - [greptimedb-standalone](./charts/greptimedb-standalone/README.md)
+- [greptimedb-cluster](./charts/greptimedb-cluster/README.md)
+- **Deprecated**: [greptimedb](./charts/greptimedb/README.md)
 
 ## License
 

--- a/charts/greptimedb-cluster/.helmignore
+++ b/charts/greptimedb-cluster/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: greptimedb
+description: A Helm chart for deploying GreptimeDB cluster in Kubernetes
+type: application
+version: 0.1.0
+appVersion: 0.4.1

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -1,0 +1,30 @@
+# Overview
+
+Helm chart for [GreptimeDB](https://github.com/GreptimeTeam/greptimedb) cluster.
+
+## How to install
+
+**Note**: Make sure you already install the [greptimedb-operator](../greptimedb-operator/README.md).
+
+```console
+# Add charts repo.
+helm repo add greptime https://greptimeteam.github.io/helm-charts/
+helm repo update
+
+# Optional: Install etcd cluster.
+# You also can use your own etcd cluster.
+helm install etcd oci://registry-1.docker.io/bitnamicharts/etcd \
+    --set replicaCount=3 \
+    --set auth.rbac.create=false \
+    --set auth.rbac.token.enabled=false \
+    -n default
+
+# Install greptimedb in default namespace.
+helm install greptimedb-cluster greptime/greptimedb-cluster -n default --devel
+```
+
+## How to uninstall
+
+```console
+helm uninstall greptimedb-cluster -n default
+```

--- a/charts/greptimedb-cluster/templates/cluster.yaml
+++ b/charts/greptimedb-cluster/templates/cluster.yaml
@@ -1,0 +1,82 @@
+apiVersion: greptime.io/v1alpha1
+kind: GreptimeDBCluster
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  base:
+    main:
+      image: '{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+      {{- if .Values.resources }}
+      resources: {{- toYaml .Values.resources | nindent 8 }}
+      {{- end }}
+    {{- if .Values.image.pullSecrets }}
+    imagePullSecrets:
+    {{- range .Values.image.pullSecrets }}
+      - name: {{ . }}
+    {{- end }}
+    {{- end }}
+  frontend:
+    replicas: {{ .Values.frontend.replicas }}
+    {{- if .Values.frontend.tls }}
+    tls:
+      secretName: {{ .Values.frontend.tls.certificates.secretName }}
+    {{- end }}
+    {{- if .Values.frontend.service }}
+    service: {{- toYaml .Values.frontend.service | nindent 6 }}
+    {{- end }}
+    {{- if .Values.frontend.componentSpec }}
+    template: {{- toYaml .Values.frontend.componentSpec | nindent 6 }}
+    {{- end }}
+  meta:
+    replicas: {{ .Values.meta.replicas }}
+    {{- if .Values.etcdEndpoints }}
+    etcdEndpoints:
+      - {{ .Values.etcdEndpoints }}
+    {{- end }}
+    {{- if .Values.meta.componentSpec }}
+    template: {{- toYaml .Values.meta.componentSpec | nindent 6 }}
+    {{- end }}
+  datanode:
+    replicas: {{ .Values.datanode.replicas }}
+    {{- if .Values.datanode.componentSpec }}
+    template: {{- toYaml .Values.datanode.componentSpec | nindent 6 }}
+    {{- end }}
+    storage:
+      storageClassName: {{ .Values.datanode.storage.storageClassName }}
+      storageSize: {{ .Values.datanode.storage.storageSize }}
+      storageRetainPolicy: {{ .Values.datanode.storage.storageRetainPolicy }}
+      {{- if .Values.datanode.storage.walDir }}
+      walDir: {{ .Values.datanode.storage.walDir }}
+      {{- end }}
+  {{- if (and .Values.prometheusMonitor (eq .Values.prometheusMonitor.enabled true ))}}
+  prometheusMonitor: {{- toYaml .Values.prometheusMonitor | nindent 4 }}
+  {{- end }}
+  httpServicePort: {{ .Values.httpServicePort }}
+  grpcServicePort: {{ .Values.grpcServicePort }}
+  mysqlServicePort: {{ .Values.mysqlServicePort }}
+  postgresServicePort: {{ .Values.postgresServicePort }}
+  openTSDBServicePort: {{ .Values.openTSDBServicePort }}
+  initializer:
+    image: '{{ .Values.initializer.registry }}/{{ .Values.initializer.repository }}:{{ .Values.initializer.tag }}'
+  storage:
+    {{- if .Values.storage.s3 }}
+    s3:
+      bucket: {{ .Values.storage.s3.bucket }}
+      region: {{ .Values.storage.s3.region }}
+      root: {{ .Values.storage.s3.root }}
+      secretName: {{ .Values.storage.s3.secretName }}
+      endpoint: {{ .Values.storage.s3.endpoint }}
+    {{- else if .Values.storage.local }}
+    local:
+      directory: {{ .Values.storage.local.directory }}
+    {{- else if .Values.storage.oss }}
+    oss:
+      bucket: {{ .Values.storage.oss.bucket }}
+      region: {{ .Values.storage.oss.region }}
+      root: {{ .Values.storage.oss.root }}
+      secretName: {{ .Values.storage.oss.secretName }}
+      endpoint: {{ .Values.storage.oss.endpoint }}
+    {{- else }}
+    {}
+    {{- end }}

--- a/charts/greptimedb-cluster/templates/credentials-sealed-secret.yaml
+++ b/charts/greptimedb-cluster/templates/credentials-sealed-secret.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.storage.credentials }}
+{{- if .Values.storage.credentials.secretCreation }}
+{{- if and (eq .Values.storage.credentials.secretCreation.enabled true) (eq .Values.storage.credentials.secretCreation.enableEncryption true) }}
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: {{ .Values.storage.credentials.secretName }}
+  namespace:  {{ .Release.Namespace }}
+spec:
+  encryptedData:
+    {{- range $key, $value := .Values.storage.credentials.secretCreation.data }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  template:
+    metadata:
+      name: {{ .Values.storage.credentials.secretName }}
+      namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/greptimedb-cluster/templates/credentials-secret.yaml
+++ b/charts/greptimedb-cluster/templates/credentials-secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.storage.credentials }}
+{{- if .Values.storage.credentials.secretCreation }}
+{{- if and (eq .Values.storage.credentials.secretCreation.enabled true) (eq .Values.storage.credentials.secretCreation.enableEncryption false) }}
+apiVersion: v1
+metadata:
+  name: {{ .Values.storage.credentials.secretName }}
+  namespace: {{ .Release.Namespace }}
+kind: Secret
+type: Opaque
+data:
+  {{- range $key, $value := .Values.storage.credentials.secretCreation.data }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/greptimedb-cluster/templates/tls-sealed-secret.yaml
+++ b/charts/greptimedb-cluster/templates/tls-sealed-secret.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.frontend.tls.certificates }}
+{{- if .Values.frontend.tls.certificates.secretCreation }}
+{{- if and (eq .Values.frontend.tls.certificates.secretCreation.enabled true) (eq .Values.frontend.tls.certificates.secretCreation.enableEncryption true)  }}
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: {{ .Values.frontend.tls.certificates.secretName }}
+  namespace:  {{ .Release.Namespace }}
+spec:
+  encryptedData:
+    {{- toYaml .Values.frontend.tls.certificates.secretCreation.data | nindent 4 }}
+  template:
+    metadata:
+      name: {{ .Values.frontend.tls.certificates.secretName }}
+      namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/greptimedb-cluster/templates/tls-secret.yaml
+++ b/charts/greptimedb-cluster/templates/tls-secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.frontend.tls.certificates }}
+{{- if .Values.frontend.tls.certificates.secretCreation }}
+{{- if and (eq .Values.frontend.tls.certificates.secretCreation.enabled true) (eq .Values.frontend.tls.certificates.secretCreation.enableEncryption false) }}
+apiVersion: v1
+metadata:
+  name: {{ .Values.frontend.tls.certificates.secretName }}
+  namespace: {{ .Release.Namespace }}
+kind: Secret
+type: kubernetes.io/tls
+data:
+  {{- toYaml .Values.frontend.tls.certificates.secretCreation.data | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -1,0 +1,112 @@
+image:
+  registry: docker.io
+  # The image repository
+  repository: greptime/greptimedb
+  # The image tag
+  tag: "v0.4.1"
+  # The image pull secrets.
+  pullSecrets: []
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+frontend:
+  replicas: 1
+  service: {}
+  componentSpec: {}
+
+  tls: {}
+#    certificates:
+#      secretName: greptimedb-frontend-tls
+#      secretCreation:
+#        enabled: true
+#        enableEncryption: false
+#        data:
+#          ca.crt: ""
+#          tls.crt: ""
+#          tls.key: ""
+
+meta:
+  replicas: 1
+  componentSpec: {}
+
+datanode:
+  replicas: 3
+  componentSpec: {}
+  storage:
+    storageClassName: null
+    storageSize: 10Gi
+    storageRetainPolicy: Retain
+
+#    # The wal directory of the storage, default is "/tmp/greptimedb/wal".
+#    walDir: "/tmp/greptimedb/wal"
+
+initializer:
+  registry: docker.io
+  repository: greptime/greptimedb-initializer
+  tag: 0.1.0-alpha.17
+
+# The etcdEndpoints need be modified to the actual etcd cluster.
+etcdEndpoints: "etcd.default.svc.cluster.local:2379"
+
+httpServicePort: 4000
+grpcServicePort: 4001
+mysqlServicePort: 4002
+postgresServicePort: 4003
+openTSDBServicePort: 4242
+
+# configure to prometheus podmonitor
+prometheusMonitor: {}
+#  enabled: true
+#  path: "/metrics"
+#  port: "http"
+#  interval: "30s"
+#  honorLabels: true
+#  labelsSelector:
+#    release: prometheus
+
+storage:
+#  credentials:
+#    secretName: "credentials"
+#    secretCreation:
+#    # Create the raw secret.
+#      enabled: true
+#      # Create the sealed secret.
+#      # If enableEncryption is true, the credentials should be encrypted.
+#      enableEncryption: false
+#
+#      # If the enableEncryption is true, the data should be set as encrypted data.
+#      data:
+#        access-key-id: "you-should-set-the-access-key-id-here"
+#        secret-access-key: "you-should-set-the-secret-access-key-here"
+
+  # configure to use local storage.
+  local: {}
+#    directory: /tmp/greptimedb
+
+  # configure to use s3 storage.
+  s3: {}
+#    bucket: "bucket-name"
+#    region: "us-west-2"
+
+#    # The root directory of the cluster.
+#    # The data directory in S3 will be: 's3://<bucket>/<root>/data/...'.
+#    root: "mycluster"
+#    endpoint: "s3.us-west-2.amazonaws.com"
+#    secretName: "credentials"
+
+  # configure to use oss storage.
+  oss: {}
+#    bucket: "bucket-name"
+#    region: "cn-hangzhou"
+
+#    # The root directory of the cluster.
+#    # The data directory in OSS will be: 'oss://<bucket>/<root>/data/...'.
+#    root: "mycluster"
+#    endpoint: "oss-cn-hangzhou.aliyuncs.com"
+#    secretName: "credentials"


### PR DESCRIPTION
## What's changed

The new chart `greptimedb-cluster` is just a copy of the `greptimedb` chart. To keep it consistent, we still keep the `greptimedb` chart and remove it in the future. 

We need a `greptimedb-cluster` chart to have a **more precise naming**(compared to `greptimedb-standalone` chart).


