### PR TITLE
refactor: support to pass config file and refactor some fields

### DIFF
--- a/charts/greptimedb-standalone/Chart.yaml
+++ b/charts/greptimedb-standalone/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: greptimedb-standalone
 description: A Helm chart for deploying standalone greptimedb
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: 0.4.2

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying standalone greptimedb
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2](https://img.shields.io/badge/AppVersion-0.4.2-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2](https://img.shields.io/badge/AppVersion-0.4.2-informational?style=flat-square)
 
 ## Source Code
 - https://github.com/GreptimeTeam/greptimedb
@@ -32,6 +32,7 @@ helm uninstall greptimedb-standalone -n default
 | annotations | object | `{}` | The annotations |
 | args | list | `[]` | The container args |
 | command | list | `[]` | The container command |
+| configToml | string | `"mode = 'standalone'\n"` | The extra configuration for greptimedb. |
 | dnsConfig | object | `{}` | DNS configuration for pod |
 | env | object | `{"GREPTIMEDB_STANDALONE__HTTP__ADDR":"0.0.0.0:4000"}` | Environment variables |
 | envFrom | object | `{}` | Maps all the keys on a configmap or secret as environment variables |
@@ -53,6 +54,7 @@ helm uninstall greptimedb-standalone -n default
 | opentsdbServicePort | int | `4242` | GreptimeDB opentsdb service port |
 | persistence.enableStatefulSetAutoDeletePVC | bool | `false` | Enable StatefulSetAutoDeletePVC feature |
 | persistence.enabled | bool | `true` | Enable persistent disk |
+| persistence.mountPath | string | `"/data/greptimedb"` | Mount path of persistent disk. |
 | persistence.selector | string | `nil` | Selector for persistent disk |
 | persistence.size | string | `"10Gi"` | Size of persistent disk |
 | persistence.storageClass | string | `nil` | Storage class name |

--- a/charts/greptimedb-standalone/templates/configmap.yaml
+++ b/charts/greptimedb-standalone/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.configToml -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.toml: |
+{{ .Values.configToml | indent 4 }}
+{{- end -}}

--- a/charts/greptimedb-standalone/templates/statefulset.yaml
+++ b/charts/greptimedb-standalone/templates/statefulset.yaml
@@ -54,14 +54,19 @@ spec:
           image: {{ printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - greptime
-            - standalone
-            - start
           {{- if .Values.command }}
             {{- toYaml .Values.command | nindent 12 }}
+          {{- else }}
+            - "greptime"
+            - "standalone"
+            - "start"
           {{- end }}
-          {{- if .Values.args }}
           args:
+            {{- if .Values.configToml }}
+            - "--config-file"
+            - "/etc/greptimedb/config.toml"
+            {{- end }}
+          {{- if .Values.args }}
             {{- toYaml .Values.args | nindent 12 }}
           {{- end }}
           ports:
@@ -97,11 +102,22 @@ spec:
           {{- end }}
           volumeMounts:
             - name: data
-              mountPath: /tmp/greptimedb
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- if .Values.configToml }}
+            - name: config
+              mountPath: /etc/greptimedb
+              readOnly: true
+            {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.configToml }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Release.Name }}-config
+      {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -32,6 +32,10 @@ command: []
 # -- The container args
 args: []
 
+# -- The extra configuration for greptimedb.
+configToml: |
+  mode = 'standalone'
+
 # -- Environment variables
 env:
   GREPTIMEDB_STANDALONE__HTTP__ADDR: "0.0.0.0:4000"
@@ -147,7 +151,6 @@ dnsConfig: {}
 # -- Grace period to allow the single binary to shutdown before it is killed
 terminationGracePeriodSeconds: 30
 
-
 persistence:
   # -- Enable persistent disk
   enabled: true
@@ -159,6 +162,8 @@ persistence:
   storageClass: null
   # -- Selector for persistent disk
   selector: null
+  # -- Mount path of persistent disk.
+  mountPath: /data/greptimedb
 
 monitoring:
   # -- Enable prometheus podmonitor


### PR DESCRIPTION
## What's changed

1. Support to pass config file by using configmap;
2. Modify `command` and bring the `greptime standalone start` to default values;
3. Add `persistence.mountPath` and set `/data/greptimedb` as default value(`/tmp/greptimedb` seems stranged since we always store temporary data in `/tmp`);