### PR TITLE
chore: add chart index

### DIFF
--- a/.github/scripts/release-charts-to-s3.sh
+++ b/.github/scripts/release-charts-to-s3.sh
@@ -44,12 +44,20 @@ function release_charts_to_s3() {
   aws s3 cp latest-version.txt s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR"/"$chart"/latest-version.txt
 }
 
+function update_index() {
+  helm plugin install https://github.com/hypnoglow/helm-s3.git
+  helm s3 init s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR" --force
+  helm repo index --url s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR" --merge index.yaml .
+  aws s3 cp index.yaml s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR"/
+}
+
 function main() {
   update_greptime_charts
   release_charts_to_s3 greptime greptimedb-operator
   release_charts_to_s3 greptime greptimedb-standalone
   release_charts_to_s3 greptime greptimedb-cluster
   release_charts_to_s3 oci://registry-1.docker.io/bitnamicharts etcd
+  update_index
 }
 
 # The entrypoint for the script.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - chore/cn-region-index
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - chore/cn-region-index
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The index use for CN documents helm chart example.

## How to use:
```
helm repo add greptime s3://greptime-release-bucket/releases/charts
helm search repo greptime/greptimedb-operator 
helm install greptime greptime/greptimedb-operator 
helm install greptime greptime/greptimedb-cluster
... 
```