### PR TITLE
chore: add cn region helm chart index

### DIFF
--- a/.github/scripts/release-charts-to-s3.sh
+++ b/.github/scripts/release-charts-to-s3.sh
@@ -62,5 +62,3 @@ function main() {
 
 # The entrypoint for the script.
 main
-
-}

--- a/.github/scripts/release-charts-to-s3.sh
+++ b/.github/scripts/release-charts-to-s3.sh
@@ -44,12 +44,20 @@ function release_charts_to_s3() {
   aws s3 cp latest-version.txt s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR"/"$chart"/latest-version.txt
 }
 
+function update_index() {
+  helm plugin install https://github.com/hypnoglow/helm-s3.git
+  helm s3 init s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR" --force
+  helm repo index --url s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR" --merge index.yaml .
+  aws s3 cp index.yaml s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR"/
+}
+
 function main() {
   update_greptime_charts
   release_charts_to_s3 greptime greptimedb-operator
   release_charts_to_s3 greptime greptimedb-standalone
   release_charts_to_s3 greptime greptimedb-cluster
   release_charts_to_s3 oci://registry-1.docker.io/bitnamicharts etcd
+  update_index
 }
 
 # The entrypoint for the script.

--- a/.github/scripts/release-charts-to-s3.sh
+++ b/.github/scripts/release-charts-to-s3.sh
@@ -10,6 +10,11 @@ function update_greptime_charts() {
   helm repo update
 }
 
+function install_helm_s3() {
+  helm plugin install https://github.com/hypnoglow/helm-s3.git
+  helm repo add greptime-cn s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR"/package
+}
+
 function release_charts_to_s3() {
   repo=$1
   chart=$2
@@ -38,27 +43,24 @@ function release_charts_to_s3() {
 
   aws s3 cp "$chart"/"$package" s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR"/"$chart"/"$version"/"$package"
 
+  helm s3 push "$chart"/"$package" greptime-cn --force
+
   echo "$version" > latest-version.txt
 
   # Create a latest-version.txt file in the chart directory.
   aws s3 cp latest-version.txt s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR"/"$chart"/latest-version.txt
 }
 
-function update_index() {
-  helm plugin install https://github.com/hypnoglow/helm-s3.git
-  helm s3 init s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR" --force
-  helm repo index --url s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR" --merge index.yaml .
-  aws s3 cp index.yaml s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR"/
-}
-
 function main() {
   update_greptime_charts
+  install_helm_s3
   release_charts_to_s3 greptime greptimedb-operator
   release_charts_to_s3 greptime greptimedb-standalone
   release_charts_to_s3 greptime greptimedb-cluster
   release_charts_to_s3 oci://registry-1.docker.io/bitnamicharts etcd
-  update_index
 }
 
 # The entrypoint for the script.
 main
+
+}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - chore/cn-region-index
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - chore/cn-region-index
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The index use for CN documents helm chart example.
Re: [1018](https://github.com/GreptimeTeam/docs/pull/1018/files#diff-f9f570914662920ed8751d996b20fb727b11552889d8ba6207efc9fa87d41c30R12)

helm-s3 tool: https://github.com/hypnoglow/helm-s3

## How to use
```
helm repo add greptime s3://greptime-release-bucket/releases/charts/package
helm search repo greptime/greptimedb-operator 
helm install greptime greptime/greptimedb-operator 
helm install greptime greptime/greptimedb-cluster
... 
```