### PR TITLE
feat: support flownode options

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.1.32
+version: 0.1.33
 appVersion: 0.8.2
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.1.32](https://img.shields.io/badge/Version-0.1.32-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
+![Version: 0.1.33](https://img.shields.io/badge/Version-0.1.33-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
 
 ## Source Code
 
@@ -111,9 +111,9 @@ helm uninstall mycluster -n default
 | datanode.storage.storageRetainPolicy | string | `"Retain"` | Storage retain policy for datanode persistent volume |
 | datanode.storage.storageSize | string | `"10Gi"` | Storage size for datanode persistent volume |
 | datanode.storage.walDir | string | `"/data/greptimedb/wal"` | The wal directory of the storage, default is "/data/greptimedb/wal" |
-| flownode | object | `{"config":"","enabled":true,"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1}` | Flownode configure |
+| flownode | object | `{"config":"","enabled":false,"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1}` | Flownode configure. **It's NOT READY YET** |
 | flownode.config | string | `""` | Extra flownode config in toml format. |
-| flownode.enabled | bool | `true` | Enable flownode |
+| flownode.enabled | bool | `false` | Enable flownode |
 | flownode.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for frontend |
 | flownode.podTemplate.affinity | object | `{}` | The pod affinity |
 | flownode.podTemplate.annotations | object | `{}` | The annotations to be created to the pod. |

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -111,6 +111,27 @@ helm uninstall mycluster -n default
 | datanode.storage.storageRetainPolicy | string | `"Retain"` | Storage retain policy for datanode persistent volume |
 | datanode.storage.storageSize | string | `"10Gi"` | Storage size for datanode persistent volume |
 | datanode.storage.walDir | string | `"/data/greptimedb/wal"` | The wal directory of the storage, default is "/data/greptimedb/wal" |
+| flownode | object | `{"config":"","enabled":true,"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1}` | Flownode configure |
+| flownode.config | string | `""` | Extra flownode config in toml format. |
+| flownode.enabled | bool | `true` | Enable flownode |
+| flownode.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for frontend |
+| flownode.podTemplate.affinity | object | `{}` | The pod affinity |
+| flownode.podTemplate.annotations | object | `{}` | The annotations to be created to the pod. |
+| flownode.podTemplate.labels | object | `{}` | The labels to be created to the pod. |
+| flownode.podTemplate.main | object | `{"args":[],"command":[],"env":[],"image":"","resources":{"limits":{},"requests":{}},"volumeMounts":[]}` | The spec of main container |
+| flownode.podTemplate.main.args | list | `[]` | The arguments to be passed to the command |
+| flownode.podTemplate.main.command | list | `[]` | The command to be executed in the container |
+| flownode.podTemplate.main.env | list | `[]` | The environment variables for the container |
+| flownode.podTemplate.main.image | string | `""` | The flownode image. |
+| flownode.podTemplate.main.resources.limits | object | `{}` | The resources limits for the container |
+| flownode.podTemplate.main.resources.requests | object | `{}` | The requested resources for the container |
+| flownode.podTemplate.main.volumeMounts | list | `[]` | The pod volumeMounts |
+| flownode.podTemplate.nodeSelector | object | `{}` | The pod node selector |
+| flownode.podTemplate.serviceAccount.annotations | object | `{}` | The annotations for flownode serviceaccount |
+| flownode.podTemplate.serviceAccount.create | bool | `false` | Create a service account |
+| flownode.podTemplate.tolerations | list | `[]` | The pod tolerations |
+| flownode.podTemplate.volumes | list | `[]` | The pod volumes |
+| flownode.replicas | int | `1` | Flownode replicas |
 | frontend | object | `{"config":"","podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"service":{},"tls":{}}` | Frontend configure |
 | frontend.config | string | `""` | Extra frontend config in toml format. |
 | frontend.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for frontend |

--- a/charts/greptimedb-cluster/templates/cluster.yaml
+++ b/charts/greptimedb-cluster/templates/cluster.yaml
@@ -207,6 +207,55 @@ spec:
       storageRetainPolicy: {{ .Values.datanode.storage.storageRetainPolicy }}
       dataHome: {{ .Values.datanode.storage.dataHome }}
       walDir: {{ .Values.datanode.storage.walDir }}
+  {{- if .Values.flownode.enabled }}
+  flownode:
+    replicas: {{ .Values.frontend.replicas }}
+    {{- if .Values.flownode.config }}
+    config: |-
+      {{ .Values.flownode.config | nindent 6 }}
+    {{- end }}
+    template:
+      main:
+        {{- if .Values.flownode.podTemplate.main.image }}
+        image: {{ .Values.flownode.podTemplate.main.image }}
+        {{- end }}
+        {{- if .Values.flownode.podTemplate.main.command }}
+        command: {{ .Values.flownode.podTemplate.main.command | toYaml | nindent 8 }}
+        {{- end }}
+        {{- if .Values.flownode.podTemplate.main.args }}
+        args: {{ .Values.flownode.podTemplate.main.args | toYaml | nindent 8 }}
+        {{- end }}
+        {{- if .Values.flownode.podTemplate.main.env }}
+        env: {{- toYaml .Values.flownode.podTemplate.main.env | nindent 8 }}
+        {{- end }}
+        {{- if .Values.flownode.podTemplate.main.volumeMounts }}
+        volumeMounts: {{- toYaml .Values.flownode.podTemplate.main.volumeMounts | nindent 8 }}
+        {{- end }}
+        resources:
+          requests: {{ .Values.flownode.podTemplate.main.resources.requests | toYaml | nindent 12 }}
+          limits: {{ .Values.flownode.podTemplate.main.resources.limits | toYaml | nindent 12 }}
+      {{- if .Values.flownode.podTemplate.annotations }}
+      annotations: {{ .Values.flownode.podTemplate.annotations | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.flownode.podTemplate.labels }}
+      labels: {{ .Values.flownode.podTemplate.labels | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.flownode.podTemplate.serviceAccount.create }}
+      serviceAccountName: {{ .Release.Name }}-flownode
+      {{- end }}
+      {{- if .Values.flownode.podTemplate.tolerations }}
+      tolerations: {{ .Values.flownode.podTemplate.tolerations | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.flownode.podTemplate.affinity }}
+      affinity: {{ .Values.flownode.podTemplate.affinity | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.flownode.podTemplate.nodeSelector }}
+      nodeSelector: {{ .Values.flownode.podTemplate.nodeSelector | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.flownode.podTemplate.volumes}}
+      volumes: {{ .Values.flownode.podTemplate.volumes | toYaml | nindent 8 }}
+      {{- end }}
+  {{- end }}
   {{- if (and .Values.prometheusMonitor (eq .Values.prometheusMonitor.enabled true ))}}
   prometheusMonitor: {{- toYaml .Values.prometheusMonitor | nindent 4 }}
   {{- end }}

--- a/charts/greptimedb-cluster/templates/serviceaccount-flownode.yaml
+++ b/charts/greptimedb-cluster/templates/serviceaccount-flownode.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.flownode.podTemplate.serviceAccount.create }}
+{{- if and .Values.flownode.enabled .Values.flownode.podTemplate.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-flownode
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.datanode.podTemplate.serviceAccount.annotations }}
+  {{- with .Values.flownode.podTemplate.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/greptimedb-cluster/templates/serviceaccount-flownode.yaml
+++ b/charts/greptimedb-cluster/templates/serviceaccount-flownode.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.flownode.podTemplate.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-flownode
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.datanode.podTemplate.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -253,6 +253,66 @@ datanode:
     # -- The wal directory of the storage, default is "/data/greptimedb/wal"
     walDir: "/data/greptimedb/wal"
 
+# -- Flownode configure
+flownode:
+  # -- Enable flownode
+  enabled: true
+
+  # -- Flownode replicas
+  replicas: 1
+
+  # -- Extra flownode config in toml format.
+  config: ""
+
+  # -- The pod template for frontend
+  podTemplate:
+    # -- The spec of main container
+    main:
+      # -- The flownode image.
+      image: ""
+
+      resources:
+        # -- The requested resources for the container
+        requests: {}
+        #  cpu: "1"
+        #  memory: "2Gi"
+
+        # -- The resources limits for the container
+        limits: {}
+        #  cpu: "1"
+        #  memory: "2Gi"
+
+      # -- The environment variables for the container
+      env: []
+
+      # -- The command to be executed in the container
+      command: []
+
+      # -- The arguments to be passed to the command
+      args: []
+
+      # -- The pod volumeMounts
+      volumeMounts: []
+
+    # -- The annotations to be created to the pod.
+    annotations: {}
+    # -- The labels to be created to the pod.
+    labels: {}
+    # -- The pod node selector
+    nodeSelector: {}
+    # -- The pod tolerations
+    tolerations: []
+    # -- The pod affinity
+    affinity: {}
+    # -- The pod volumes
+    volumes: []
+
+    serviceAccount:
+      # -- Create a service account
+      create: false
+      # -- The annotations for flownode serviceaccount
+      annotations: {}
+
 # -- GreptimeDB http service port
 httpServicePort: 4000
 # -- GreptimeDB grpc service port

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -253,10 +253,10 @@ datanode:
     # -- The wal directory of the storage, default is "/data/greptimedb/wal"
     walDir: "/data/greptimedb/wal"
 
-# -- Flownode configure
+# -- Flownode configure. **It's NOT READY YET**
 flownode:
   # -- Enable flownode
-  enabled: true
+  enabled: false
 
   # -- Flownode replicas
   replicas: 1


### PR DESCRIPTION
## What's changed

Support the `flownode` config in `greptimedb-cluster` chart. Since the operator and formal greptimedb release are not ready, the default `.Values.flownode.enabled` is `false`.