### PR TITLE
chore: bump greptimedb-operator version

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.1.36
+version: 0.2.0
 appVersion: 0.9.0
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.1.36](https://img.shields.io/badge/Version-0.1.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
 
 ## Source Code
 
@@ -162,7 +162,7 @@ helm uninstall mycluster -n default
 | image.tag | string | `"v0.9.0"` | The image tag |
 | initializer.registry | string | `"docker.io"` | Initializer image registry |
 | initializer.repository | string | `"greptime/greptimedb-initializer"` | Initializer image repository |
-| initializer.tag | string | `"0.1.0-alpha.27"` | Initializer image tag |
+| initializer.tag | string | `"0.1.0-alpha.28"` | Initializer image tag |
 | meta | object | `{"config":"","enableRegionFailover":false,"etcdEndpoints":"etcd.default.svc.cluster.local:2379","podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"storeKeyPrefix":""}` | Meta configure |
 | meta.config | string | `""` | Extra Meta config in toml format. |
 | meta.enableRegionFailover | bool | `false` | Whether to enable region failover |

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -14,7 +14,7 @@ initializer:
   # -- Initializer image repository
   repository: greptime/greptimedb-initializer
   # -- Initializer image tag
-  tag: 0.1.0-alpha.27
+  tag: 0.1.0-alpha.28
 
 base:
   # -- The pod template for base

--- a/charts/greptimedb-operator/Chart.yaml
+++ b/charts/greptimedb-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 kubeVersion: ">=1.18.0-0"
 description: The greptimedb-operator Helm chart for Kubernetes.
 name: greptimedb-operator
-appVersion: 0.1.0-alpha.27
-version: 0.1.20
+appVersion: 0.1.0-alpha.28
+version: 0.2.0
 type: application
 home: https://github.com/GreptimeTeam/greptimedb-operator
 sources:

--- a/charts/greptimedb-operator/README.md
+++ b/charts/greptimedb-operator/README.md
@@ -2,7 +2,7 @@
 
 The greptimedb-operator Helm chart for Kubernetes.
 
-![Version: 0.1.20](https://img.shields.io/badge/Version-0.1.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0-alpha.27](https://img.shields.io/badge/AppVersion-0.1.0--alpha.27-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0-alpha.28](https://img.shields.io/badge/AppVersion-0.1.0--alpha.28-informational?style=flat-square)
 
 ## Source Code
 
@@ -78,7 +78,7 @@ Kubernetes: `>=1.18.0-0`
 | image.pullSecrets | list | `[]` | The image pull secrets |
 | image.registry | string | `"docker.io"` | The image registry |
 | image.repository | string | `"greptime/greptimedb-operator"` | The image repository |
-| image.tag | string | `"0.1.0-alpha.27"` | The image tag |
+| image.tag | string | `"0.1.0-alpha.28"` | The image tag |
 | nameOverride | string | `""` | String to partially override release template name |
 | nodeSelector | object | `{}` | The operator node selector |
 | rbac.create | bool | `true` | Install role based access control |

--- a/charts/greptimedb-operator/values.yaml
+++ b/charts/greptimedb-operator/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- The image pull policy for the controller
   imagePullPolicy: IfNotPresent
   # -- The image tag
-  tag: 0.1.0-alpha.27
+  tag: 0.1.0-alpha.28
   # -- The image pull secrets
   pullSecrets: []
 


### PR DESCRIPTION
Let's move to `0.2.x`! 🎉

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the version of the GreptimeDB cluster and operator Helm charts to 0.2.0, indicating significant enhancements.
	- Incremented initializer image version to 0.1.0-alpha.28 for both GreptimeDB cluster and operator.

- **Documentation**
	- Updated README files for both the GreptimeDB cluster and operator to reflect new versioning details, including changes to the initializer image tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->