### PR TITLE
fix: incorrect field remoteWAL -> remoteWal

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.9.0
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
 
 ## Source Code
 
@@ -198,7 +198,7 @@ helm uninstall mycluster -n default
 | prometheusMonitor.enabled | bool | `false` | Create PodMonitor resource for scraping metrics using PrometheusOperator |
 | prometheusMonitor.interval | string | `"30s"` | Interval at which metrics should be scraped |
 | prometheusMonitor.labels | object | `{"release":"prometheus"}` | Add labels to the PodMonitor |
-| remoteWAL | object | `{"enabled":false,"kafka":{"brokerEndpoints":[]}}` | Configure to remote wal |
-| remoteWAL.enabled | bool | `false` | Enable remote wal |
-| remoteWAL.kafka | object | `{"brokerEndpoints":[]}` | The remote wal type, only support kafka now. |
-| remoteWAL.kafka.brokerEndpoints | list | `[]` | The kafka broker endpoints |
+| remoteWal | object | `{"enabled":false,"kafka":{"brokerEndpoints":[]}}` | Configure to remote wal |
+| remoteWal.enabled | bool | `false` | Enable remote wal |
+| remoteWal.kafka | object | `{"brokerEndpoints":[]}` | The remote wal type, only support kafka now. |
+| remoteWal.kafka.brokerEndpoints | list | `[]` | The kafka broker endpoints |

--- a/charts/greptimedb-cluster/templates/cluster.yaml
+++ b/charts/greptimedb-cluster/templates/cluster.yaml
@@ -298,9 +298,9 @@ spec:
     {{- else }}
     {}
     {{- end }}
-  {{- if .Values.remoteWAL.enabled }}
-  remoteWAL:
-  {{- if .Values.remoteWAL.kafka }}
-    kafka: {{- toYaml .Values.remoteWAL.kafka | nindent 6 }}
+  {{- if .Values.remoteWal.enabled }}
+  remoteWal:
+  {{- if .Values.remoteWal.kafka }}
+    kafka: {{- toYaml .Values.remoteWal.kafka | nindent 6 }}
   {{- end }}
   {{- end }}

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -423,7 +423,7 @@ objectStorage:
 #    endpoint: "oss-cn-hangzhou.aliyuncs.com"
 
 # -- Configure to remote wal
-remoteWAL:
+remoteWal:
   # -- Enable remote wal
   enabled: false
   # -- The remote wal type, only support kafka now.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated version of the GreptimeDB Helm chart from 0.2.2 to 0.2.3, reflecting minor improvements and bug fixes.
	- Renamed configuration parameters for consistency, changing `remoteWAL` to `remoteWal`.

- **Documentation**
	- Updated README to reflect new versioning and configuration parameter naming conventions.

- **Chores**
	- Standardized naming conventions in configuration files to enhance usability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->