### PR TITLE
feat: Add Support for Using Existing Secrets in greptimedb-cluster Helm Chart for Secure Credential Management

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.2.3
-appVersion: 0.9.0
+version: 0.2.5
+appVersion: 0.9.1
 home: https://github.com/GreptimeTeam/greptimedb
 sources:
   - https://github.com/GreptimeTeam/greptimedb

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
+![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.1](https://img.shields.io/badge/AppVersion-0.9.1-informational?style=flat-square)
 
 ## Source Code
 

--- a/charts/greptimedb-cluster/templates/cluster.yaml
+++ b/charts/greptimedb-cluster/templates/cluster.yaml
@@ -285,7 +285,11 @@ spec:
     s3: {{- toYaml .Values.objectStorage.s3 | nindent 6 }}
       {{- if .Values.objectStorage }}
       {{- if .Values.objectStorage.credentials }}
+      {{- if .Values.objectStorage.credentials.existingSecretName }}
+      secretName: {{ .Values.objectStorage.credentials.existingSecretName }}
+      {{- else }}
       secretName: {{ default "storage-credentials" .Values.objectStorage.credentials.secretName }}
+      {{- end }}
       {{- end }}
       {{- end }}
     {{- else if .Values.objectStorage.oss }}

--- a/charts/greptimedb-cluster/templates/cluster.yaml
+++ b/charts/greptimedb-cluster/templates/cluster.yaml
@@ -296,7 +296,11 @@ spec:
     oss: {{- toYaml .Values.objectStorage.oss | nindent 6 }}
       {{- if .Values.objectStorage }}
       {{- if .Values.objectStorage.credentials }}
+      {{- if .Values.objectStorage.credentials.existingSecretName }}
+      secretName: {{ .Values.objectStorage.credentials.existingSecretName }}
+      {{- else }}
       secretName: {{ default "storage-credentials" .Values.objectStorage.credentials.secretName }}
+      {{- end }}
       {{- end }}
       {{- end }}
     {{- else }}

--- a/charts/greptimedb-cluster/templates/secret.yaml
+++ b/charts/greptimedb-cluster/templates/secret.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.objectStorage }}
 {{- if .Values.objectStorage.credentials }}
-{{- if .Values.objectStorage.credentials.existingSecretName }}
-{{- else }}
+{{- if not .Values.objectStorage.credentials.existingSecretName }}
 apiVersion: v1
 metadata:
   name: {{ default "storage-credentials" .Values.objectStorage.credentials.secretName }}

--- a/charts/greptimedb-cluster/templates/secret.yaml
+++ b/charts/greptimedb-cluster/templates/secret.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.objectStorage }}
 {{- if .Values.objectStorage.credentials }}
+{{- if .Values.objectStorage.credentials.existingSecretName }}
+{{- else }}
 apiVersion: v1
 metadata:
   name: {{ default "storage-credentials" .Values.objectStorage.credentials.secretName }}
@@ -9,5 +11,6 @@ type: Opaque
 stringData:
   access-key-id: {{ .Values.objectStorage.credentials.accessKeyId }}
   secret-access-key: {{ .Values.objectStorage.credentials.secretAccessKey }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -403,6 +403,7 @@ objectStorage:
 #    accessKeyId: "you-should-set-the-access-key-id-here"
 #    secretAccessKey: "you-should-set-the-secret-access-key-here"
 #    secretName: ""
+#    existingSecretName: ""
 
   # configure to use s3 storage.
   s3: {}


### PR DESCRIPTION
This PR introduces a new feature that allows the use of a third-party tool for securely storing credentials outside of the Helm chart.

Currently, the greptimedb-cluster Helm chart does not support this capability, as the 'objectStorage.credentials.secretName' setting only changes the name of the automatically created secret.

With my changes, a new setting, 'objectStorage.credentials.existingSecretName', is added to the values YAML file. By specifying a value for this new setting, the default secret will not be created. Instead, the reference will point to the existing secret specified, allowing for more flexible and secure credential management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new configuration option allowing users to specify an existing secret name for object storage, enhancing flexibility in credential management.
	- Added conditional logic to the YAML templates to support the use of existing secret names, preventing the creation of duplicate secrets.
	- Updated the Helm chart version to indicate new features or improvements in the GreptimeDB cluster deployment.

- **Documentation**
	- Updated versioning information in the README to reflect the latest Helm chart version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->