### PR TITLE
ci: release charts to ACR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -23,9 +23,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.12.1
+        uses: azure/setup-helm@v4.2.0
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
@@ -35,6 +33,26 @@ jobs:
           CR_SKIP_EXISTING: true
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
+  release-charts-to-acr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+
+      - name: Login to OCI registry
+        run: echo '${{ secrets.ALICLOUD_PASSWORD }}' | helm registry login ${{ vars.OCI_REGISTRY_URL }} -u ${{ secrets.ALICLOUD_USERNAME }} --password-stdin
+
+      - name: Package and push Helm Charts
+        shell: bash
+        env:
+          OCI_REGISTRY_URL: ${{ vars.OCI_REGISTRY_URL }}
+          OCI_NAMESPACE: ${{ vars.OCI_NAMESPACE }}
+        run: |
+          ./scripts/release-charts-to-acr.sh
+
   release-charts-to-s3:
     needs: [
       release,
@@ -42,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,6 +59,11 @@ jobs:
     ]
     runs-on: ubuntu-latest
     steps:
+      # TODO(zyy17): Maybe it's not a elegant way to wait for GitHub Pages to update. For many scenarios, waiting for 5 minutes is enough.
+      - name: Wait for deployment of GitHub Pages
+        run: |
+          sleep 300
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/scripts/release-charts-to-acr.sh
+++ b/scripts/release-charts-to-acr.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+OCI_REGISTRY_URL=${OCI_REGISTRY_URL:-"greptime-registry.cn-hangzhou.cr.aliyuncs.com"}
+OCI_NAMESPACE=${OCI_NAMESPACE:-"charts"}
+CHARTS_DIR="charts"
+
+for dir in "$CHARTS_DIR"/*/; do
+  # Ensure the directory exists and is not empty.
+  if [ -d "$dir" ]; then
+    # Get the chart name from the directory path.
+    chart_name=$(basename "$dir")
+
+    # Package the chart, specifying the directory and output path directly.
+    helm package "$dir" --destination "$dir"
+
+    # Get the packaged chart file path.
+    packaged_file=$(find "$dir" -type f -name "*.tgz")
+
+    echo "Package $chart_name to $packaged_file and push to oci://$OCI_REGISTRY_URL/$OCI_NAMESPACE/$chart_name ..."
+
+    # Push the packaged chart to the OCI repository, handling the output path.
+    helm push "${packaged_file}" "oci://$OCI_REGISTRY_URL/$OCI_NAMESPACE"
+  fi
+done


### PR DESCRIPTION
Also resolve https://github.com/GreptimeTeam/helm-charts/issues/108 by adding `sleep 300`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new job for releasing Helm charts directly to an Azure Container Registry, enhancing deployment capabilities.
  - Added a script to automate the packaging and pushing of Helm charts to an OCI-compliant registry.

- **Improvements**
  - Upgraded GitHub Actions workflow actions to their latest versions for improved functionality and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->