### PR TITLE
refactor: add static auth configuration

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.2.6
+version: 0.2.7
 appVersion: 0.9.1
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.1](https://img.shields.io/badge/AppVersion-0.9.1-informational?style=flat-square)
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.1](https://img.shields.io/badge/AppVersion-0.9.1-informational?style=flat-square)
 
 ## Source Code
 
@@ -73,6 +73,11 @@ helm uninstall mycluster -n default
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| auth | object | `{"enabled":false,"fileName":"passwd","mountPath":"/etc/greptimedb/auth","users":[{"password":"admin","username":"admin"}]}` | The static auth for greptimedb, only support one user now(https://docs.greptime.com/user-guide/clients/authentication#authentication). |
+| auth.enabled | bool | `false` | Enable static auth |
+| auth.fileName | string | `"passwd"` | The auth file name, the full path is `${mountPath}/${fileName}` |
+| auth.mountPath | string | `"/etc/greptimedb/auth"` | The auth file path to store the auth info |
+| auth.users | list | `[{"password":"admin","username":"admin"}]` | The users to be created in the auth file |
 | base.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"readinessProbe":{},"resources":{"limits":{},"requests":{}}},"nodeSelector":{},"serviceAccountName":"","tolerations":[]}` | The pod template for base |
 | base.podTemplate.affinity | object | `{}` | The pod affinity |
 | base.podTemplate.annotations | object | `{}` | The annotations to be created to the pod. |

--- a/charts/greptimedb-cluster/templates/cluster.yaml
+++ b/charts/greptimedb-cluster/templates/cluster.yaml
@@ -74,11 +74,25 @@ spec:
         {{- if .Values.frontend.podTemplate.main.args }}
         args: {{ .Values.frontend.podTemplate.main.args | toYaml | nindent 8 }}
         {{- end }}
-        {{- if .Values.frontend.podTemplate.main.env }}
-        env: {{- toYaml .Values.frontend.podTemplate.main.env | nindent 8 }}
+        {{- if or .Values.auth.enabled .Values.frontend.podTemplate.main.env }}
+        env:
+        {{- if .Values.auth.enabled }}
+        - name: GREPTIMEDB_FRONTEND__USER_PROVIDER
+          value: "static_user_provider:file:{{ .Values.auth.mountPath }}/{{ .Values.auth.fileName }}"
         {{- end }}
+        {{- if .Values.frontend.podTemplate.main.env }}
+        {{- toYaml .Values.frontend.podTemplate.main.env | nindent 8 }}
+        {{- end }}
+        {{- end }}
+        {{- if or .Values.auth.enabled .Values.frontend.podTemplate.main.volumeMounts }}
+        volumeMounts:
         {{- if .Values.frontend.podTemplate.main.volumeMounts }}
-        volumeMounts: {{- toYaml .Values.frontend.podTemplate.main.volumeMounts | nindent 8 }}
+        {{- toYaml .Values.frontend.podTemplate.main.volumeMounts | nindent 8 }}
+        {{- end }}
+        {{- if .Values.auth.enabled }}
+        - name: auth
+          mountPath: {{ .Values.auth.mountPath }}
+        {{- end }}
         {{- end }}
         resources:
           requests: {{ .Values.frontend.podTemplate.main.resources.requests | toYaml | nindent 12 }}
@@ -104,8 +118,16 @@ spec:
       {{- if .Values.frontend.podTemplate.nodeSelector }}
       nodeSelector: {{ .Values.frontend.podTemplate.nodeSelector | toYaml | nindent 8 }}
       {{- end }}
-      {{- if .Values.frontend.podTemplate.volumes}}
-      volumes: {{ .Values.frontend.podTemplate.volumes | toYaml | nindent 8 }}
+      {{- if or .Values.auth.enabled .Values.frontend.podTemplate.volumes }}
+      volumes:
+      {{- if .Values.frontend.podTemplate.volumes }}
+      {{- toYaml .Values.frontend.podTemplate.volumes | nindent 8 }}
+      {{- end }}
+      {{- if .Values.auth.enabled }}
+      - name: auth
+        secret:
+          secretName: {{ .Release.Name }}-users-auth
+      {{- end }}
       {{- end }}
   meta:
     replicas: {{ .Values.meta.replicas }}

--- a/charts/greptimedb-cluster/templates/users-auth-secret.yaml
+++ b/charts/greptimedb-cluster/templates/users-auth-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.auth.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-users-auth
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  {{ .Values.auth.fileName }}: |
+    {{- range .Values.auth.users }}
+    {{ printf "%s=%s" .username .password }}
+    {{- end }}
+{{- end }}

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -443,3 +443,16 @@ remoteWal:
   kafka:
     # -- The kafka broker endpoints
     brokerEndpoints: []
+
+# -- The static auth for greptimedb, only support one user now(https://docs.greptime.com/user-guide/clients/authentication#authentication).
+auth:
+  # -- Enable static auth
+  enabled: false
+  # -- The auth file path to store the auth info
+  mountPath: "/etc/greptimedb/auth"
+  # -- The auth file name, the full path is `${mountPath}/${fileName}`
+  fileName: "passwd"
+  # -- The users to be created in the auth file
+  users:
+    - username: "admin"
+      password: "admin"


### PR DESCRIPTION
In the future, we plan to support `GreptimeDBUser` in the operator https://github.com/GreptimeTeam/greptimedb-operator/issues/145. For now, we can just add the simple configuration in the chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the Helm chart version from 0.2.6 to 0.2.7, signaling potential new features or improvements.
	- Introduced new static authentication configuration options, enhancing security management.

- **Documentation**
	- Enhanced README documentation with detailed descriptions of the new authentication configuration parameters and usage guidance.

- **Improvements**
	- Updated environment variable handling in the Kubernetes template to support the new authentication settings effectively.
	- Added logic for conditional creation of user credentials in Kubernetes Secret for improved security.
	- Refined volume mounts and management to adapt to different deployment scenarios based on authentication settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->