### PR TITLE
chore: bump greptimedb-operator to v0.1.0

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: 0.9.3
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.2.12](https://img.shields.io/badge/Version-0.2.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.3](https://img.shields.io/badge/AppVersion-0.9.3-informational?style=flat-square)
+![Version: 0.2.13](https://img.shields.io/badge/Version-0.2.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.3](https://img.shields.io/badge/AppVersion-0.9.3-informational?style=flat-square)
 
 ## Source Code
 
@@ -92,7 +92,7 @@ helm uninstall mycluster -n default
 | base.podTemplate.nodeSelector | object | `{}` | The pod node selector |
 | base.podTemplate.serviceAccountName | string | `""` | The global service account |
 | base.podTemplate.tolerations | list | `[]` | The pod tolerations |
-| datanode | object | `{"configData":"","configFile":"","podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":3,"storage":{"dataHome":"/data/greptimedb","storageClassName":null,"storageRetainPolicy":"Retain","storageSize":"10Gi","walDir":"/data/greptimedb/wal"}}` | Datanode configure |
+| datanode | object | `{"configData":"","configFile":"","podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":3,"storage":{"dataHome":"/data/greptimedb","mountPath":"/data/greptimedb","storageClassName":null,"storageRetainPolicy":"Retain","storageSize":"10Gi","walDir":"/data/greptimedb/wal"}}` | Datanode configure |
 | datanode.configData | string | `""` | Extra raw toml config data of datanode. Skip if the `configFile` is used. |
 | datanode.configFile | string | `""` | Extra toml file of datanode. |
 | datanode.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for datanode |
@@ -115,10 +115,11 @@ helm uninstall mycluster -n default
 | datanode.podTemplate.volumes | list | `[]` | The pod volumes |
 | datanode.replicas | int | `3` | Datanode replicas |
 | datanode.storage.dataHome | string | `"/data/greptimedb"` | The dataHome directory, default is "/data/greptimedb/" |
+| datanode.storage.mountPath | string | `"/data/greptimedb"` | The data directory of the storage, default is "/data/greptimedb" |
 | datanode.storage.storageClassName | string | `nil` | Storage class for datanode persistent volume |
 | datanode.storage.storageRetainPolicy | string | `"Retain"` | Storage retain policy for datanode persistent volume |
 | datanode.storage.storageSize | string | `"10Gi"` | Storage size for datanode persistent volume |
-| datanode.storage.walDir | string | `"/data/greptimedb/wal"` | The wal directory of the storage, default is "/data/greptimedb/wal" |
+| datanode.storage.walDir | string | `"/data/greptimedb/wal"` | deprecated |
 | debugPod.enabled | bool | `false` | Enable debug pod |
 | debugPod.image | object | `{"registry":"docker.io","repository":"greptime/greptime-tool","tag":"20240905-67eaa147"}` | The debug pod image |
 | debugPod.resources | object | `{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | The debug pod resource |
@@ -178,11 +179,11 @@ helm uninstall mycluster -n default
 | initializer.registry | string | `"docker.io"` | Initializer image registry |
 | initializer.repository | string | `"greptime/greptimedb-initializer"` | Initializer image repository |
 | initializer.tag | string | `"v0.1.0-alpha.29"` | Initializer image tag |
-| meta | object | `{"configData":"","configFile":"","enableRegionFailover":false,"etcdEndpoints":"etcd.default.svc.cluster.local:2379","podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"readinessProbe":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"storeKeyPrefix":""}` | Meta configure |
+| meta | object | `{"configData":"","configFile":"","enableRegionFailover":false,"etcdEndpoints":"etcd.etcd-cluster.svc.cluster.local:2379","podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"readinessProbe":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"storeKeyPrefix":""}` | Meta configure |
 | meta.configData | string | `""` | Extra raw toml config data of meta. Skip if the `configFile` is used. |
 | meta.configFile | string | `""` | Extra toml file of meta. |
 | meta.enableRegionFailover | bool | `false` | Whether to enable region failover |
-| meta.etcdEndpoints | string | `"etcd.default.svc.cluster.local:2379"` | Meta etcd endpoints |
+| meta.etcdEndpoints | string | `"etcd.etcd-cluster.svc.cluster.local:2379"` | Meta etcd endpoints |
 | meta.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"readinessProbe":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for meta |
 | meta.podTemplate.affinity | object | `{}` | The pod affinity |
 | meta.podTemplate.annotations | object | `{}` | The annotations to be created to the pod. |

--- a/charts/greptimedb-cluster/templates/cluster.yaml
+++ b/charts/greptimedb-cluster/templates/cluster.yaml
@@ -248,11 +248,12 @@ spec:
       volumes: {{ .Values.datanode.podTemplate.volumes | toYaml | nindent 8 }}
       {{- end }}
     storage:
-      storageClassName: {{ .Values.datanode.storage.storageClassName }}
-      storageSize: {{ .Values.datanode.storage.storageSize }}
-      storageRetainPolicy: {{ .Values.datanode.storage.storageRetainPolicy }}
       dataHome: {{ .Values.datanode.storage.dataHome }}
-      walDir: {{ .Values.datanode.storage.walDir }}
+      fs:
+        storageClassName: {{ .Values.datanode.storage.storageClassName }}
+        storageSize: {{ .Values.datanode.storage.storageSize }}
+        storageRetainPolicy: {{ .Values.datanode.storage.storageRetainPolicy }}
+        mountPath: {{ .Values.datanode.storage.mountPath }}
   {{- if .Values.flownode.enabled }}
   flownode:
     replicas: {{ .Values.flownode.replicas }}
@@ -312,10 +313,10 @@ spec:
   {{- if (and .Values.prometheusMonitor (eq .Values.prometheusMonitor.enabled true ))}}
   prometheusMonitor: {{- toYaml .Values.prometheusMonitor | nindent 4 }}
   {{- end }}
-  httpServicePort: {{ .Values.httpServicePort }}
-  grpcServicePort: {{ .Values.grpcServicePort }}
-  mysqlServicePort: {{ .Values.mysqlServicePort }}
-  postgresServicePort: {{ .Values.postgresServicePort }}
+  httpPort: {{ .Values.httpServicePort }}
+  rpcPort: {{ .Values.grpcServicePort }}
+  mysqlPort: {{ .Values.mysqlServicePort }}
+  postgreSQLPort: {{ .Values.postgresServicePort }}
   initializer:
     image: '{{ .Values.initializer.registry }}/{{ .Values.initializer.repository }}:{{ .Values.initializer.tag }}'
   objectStorage:
@@ -356,7 +357,7 @@ spec:
     {}
     {{- end }}
   {{- if .Values.remoteWal.enabled }}
-  remoteWal:
+  wal:
   {{- if .Values.remoteWal.kafka }}
     kafka: {{- toYaml .Values.remoteWal.kafka | nindent 6 }}
   {{- end }}

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -221,7 +221,7 @@ meta:
       annotations: {}
 
   # -- Meta etcd endpoints
-  etcdEndpoints: "etcd.default.svc.cluster.local:2379"
+  etcdEndpoints: "etcd.etcd-cluster.svc.cluster.local:2379"
 
   # -- Meta will store data with this key prefix
   storeKeyPrefix: ""
@@ -311,7 +311,10 @@ datanode:
     storageRetainPolicy: Retain
     # -- The dataHome directory, default is "/data/greptimedb/"
     dataHome: "/data/greptimedb"
+    # -- The data directory of the storage, default is "/data/greptimedb"
+    mountPath: "/data/greptimedb"
     # -- The wal directory of the storage, default is "/data/greptimedb/wal"
+    # -- deprecated
     walDir: "/data/greptimedb/wal"
 
 # -- Flownode configure. **It's NOT READY YET**

--- a/charts/greptimedb-operator/Chart.yaml
+++ b/charts/greptimedb-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 kubeVersion: ">=1.18.0-0"
 description: The greptimedb-operator Helm chart for Kubernetes.
 name: greptimedb-operator
-appVersion: 0.1.0-alpha.29
-version: 0.2.3
+appVersion: 0.1.0
+version: 0.2.4
 type: application
 home: https://github.com/GreptimeTeam/greptimedb-operator
 sources:

--- a/charts/greptimedb-operator/README.md
+++ b/charts/greptimedb-operator/README.md
@@ -2,7 +2,7 @@
 
 The greptimedb-operator Helm chart for Kubernetes.
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0-alpha.29](https://img.shields.io/badge/AppVersion-0.1.0--alpha.29-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 ## Source Code
 

--- a/charts/greptimedb-operator/templates/crds/crd-greptimedbcluster.yaml
+++ b/charts/greptimedb-operator/templates/crds/crd-greptimedbcluster.yaml
@@ -95,6 +95,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     fieldRef:
                                       properties:
                                         apiVersion:
@@ -104,6 +105,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     resourceFieldRef:
                                       properties:
                                         containerName:
@@ -119,6 +121,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     secretKeyRef:
                                       properties:
                                         key:
@@ -130,6 +133,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                               required:
                                 - name
@@ -145,6 +149,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 prefix:
                                   type: string
                                 secretRef:
@@ -154,6 +159,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             type: array
                           image:
@@ -445,8 +451,33 @@ spec:
                                 format: int32
                                 type: integer
                             type: object
+                          resizePolicy:
+                            items:
+                              properties:
+                                resourceName:
+                                  type: string
+                                restartPolicy:
+                                  type: string
+                              required:
+                                - resourceName
+                                - restartPolicy
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
                           resources:
                             properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
                               limits:
                                 additionalProperties:
                                   anyOf:
@@ -464,6 +495,8 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
+                          restartPolicy:
+                            type: string
                           securityContext:
                             properties:
                               allowPrivilegeEscalation:
@@ -693,6 +726,7 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   weight:
                                     format: int32
                                     type: integer
@@ -739,10 +773,12 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   type: array
                               required:
                                 - nodeSelectorTerms
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
                           properties:
@@ -774,6 +810,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -797,6 +834,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -840,6 +878,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -863,6 +902,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     items:
                                       type: string
@@ -904,6 +944,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -927,6 +968,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -970,6 +1012,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -993,6 +1036,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     items:
                                       type: string
@@ -1019,6 +1063,7 @@ spec:
                           name:
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       type: array
                     initContainers:
                       items:
@@ -1051,6 +1096,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     fieldRef:
                                       properties:
                                         apiVersion:
@@ -1060,6 +1106,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     resourceFieldRef:
                                       properties:
                                         containerName:
@@ -1075,6 +1122,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     secretKeyRef:
                                       properties:
                                         key:
@@ -1086,6 +1134,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                               required:
                                 - name
@@ -1101,6 +1150,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 prefix:
                                   type: string
                                 secretRef:
@@ -1110,6 +1160,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             type: array
                           image:
@@ -1401,8 +1452,33 @@ spec:
                                 format: int32
                                 type: integer
                             type: object
+                          resizePolicy:
+                            items:
+                              properties:
+                                resourceName:
+                                  type: string
+                                restartPolicy:
+                                  type: string
+                              required:
+                                - resourceName
+                                - restartPolicy
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
                           resources:
                             properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
                               limits:
                                 additionalProperties:
                                   anyOf:
@@ -1420,6 +1496,8 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
+                          restartPolicy:
+                            type: string
                           securityContext:
                             properties:
                               allowPrivilegeEscalation:
@@ -1641,6 +1719,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     properties:
                                       apiVersion:
@@ -1650,6 +1729,7 @@ spec:
                                     required:
                                       - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -1665,6 +1745,7 @@ spec:
                                     required:
                                       - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     properties:
                                       key:
@@ -1676,6 +1757,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                               - name
@@ -1946,6 +2028,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -2079,6 +2173,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               user:
                                 type: string
                             required:
@@ -2095,6 +2190,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               volumeID:
                                 type: string
                             required:
@@ -2125,6 +2221,7 @@ spec:
                               optional:
                                 type: boolean
                             type: object
+                            x-kubernetes-map-type: atomic
                           csi:
                             properties:
                               driver:
@@ -2136,6 +2233,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               readOnly:
                                 type: boolean
                               volumeAttributes:
@@ -2162,6 +2260,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     mode:
                                       format: int32
                                       type: integer
@@ -2182,6 +2281,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   required:
                                     - path
                                   type: object
@@ -2222,6 +2322,7 @@ spec:
                                           - kind
                                           - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       dataSourceRef:
                                         properties:
                                           apiGroup:
@@ -2230,12 +2331,26 @@ spec:
                                             type: string
                                           name:
                                             type: string
+                                          namespace:
+                                            type: string
                                         required:
                                           - kind
                                           - name
                                         type: object
                                       resources:
                                         properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
                                           limits:
                                             additionalProperties:
                                               anyOf:
@@ -2276,6 +2391,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       storageClassName:
                                         type: string
                                       volumeMode:
@@ -2322,6 +2438,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                             required:
                               - driver
                             type: object
@@ -2406,6 +2523,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               targetPortal:
                                 type: string
                             required:
@@ -2486,6 +2604,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     downwardAPI:
                                       properties:
                                         items:
@@ -2500,6 +2619,7 @@ spec:
                                                 required:
                                                   - fieldPath
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               mode:
                                                 format: int32
                                                 type: integer
@@ -2520,6 +2640,7 @@ spec:
                                                 required:
                                                   - resource
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                             required:
                                               - path
                                             type: object
@@ -2547,6 +2668,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     serviceAccountToken:
                                       properties:
                                         audience:
@@ -2601,6 +2723,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               user:
                                 type: string
                             required:
@@ -2622,6 +2745,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               sslEnabled:
                                 type: boolean
                               storageMode:
@@ -2673,6 +2797,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               volumeName:
                                 type: string
                               volumeNamespace:
@@ -2700,30 +2825,58 @@ spec:
                   properties:
                     config:
                       type: string
+                    httpPort:
+                      format: int32
+                      type: integer
+                    logging:
+                      properties:
+                        format:
+                          enum:
+                            - json
+                            - text
+                          type: string
+                        level:
+                          enum:
+                            - info
+                            - error
+                            - warn
+                            - debug
+                          type: string
+                        logsDir:
+                          type: string
+                        onlyLogToStdout:
+                          type: boolean
+                        persistentWithData:
+                          type: boolean
+                      type: object
                     replicas:
                       format: int32
                       minimum: 0
+                      type: integer
+                    rpcPort:
+                      format: int32
                       type: integer
                     storage:
                       properties:
                         dataHome:
                           type: string
-                        mountPath:
-                          type: string
-                        name:
-                          type: string
-                        storageClassName:
-                          type: string
-                        storageRetainPolicy:
-                          enum:
-                            - Retain
-                            - Delete
-                          type: string
-                        storageSize:
-                          pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
-                          type: string
-                        walDir:
-                          type: string
+                        fs:
+                          properties:
+                            mountPath:
+                              type: string
+                            name:
+                              type: string
+                            storageClassName:
+                              type: string
+                            storageRetainPolicy:
+                              enum:
+                                - Retain
+                                - Delete
+                              type: string
+                            storageSize:
+                              pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
+                              type: string
+                          type: object
                       type: object
                     template:
                       properties:
@@ -2761,6 +2914,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         fieldRef:
                                           properties:
                                             apiVersion:
@@ -2770,6 +2924,7 @@ spec:
                                           required:
                                             - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resourceFieldRef:
                                           properties:
                                             containerName:
@@ -2785,6 +2940,7 @@ spec:
                                           required:
                                             - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           properties:
                                             key:
@@ -2796,6 +2952,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                   required:
                                     - name
@@ -2811,6 +2968,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       type: string
                                     secretRef:
@@ -2820,6 +2978,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
                               image:
@@ -3111,8 +3270,33 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                items:
+                                  properties:
+                                    resourceName:
+                                      type: string
+                                    restartPolicy:
+                                      type: string
+                                  required:
+                                    - resourceName
+                                    - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -3130,6 +3314,8 @@ spec:
                                       x-kubernetes-int-or-string: true
                                     type: object
                                 type: object
+                              restartPolicy:
+                                type: string
                               securityContext:
                                 properties:
                                   allowPrivilegeEscalation:
@@ -3359,6 +3545,7 @@ spec:
                                               type: object
                                             type: array
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       weight:
                                         format: int32
                                         type: integer
@@ -3405,10 +3592,12 @@ spec:
                                               type: object
                                             type: array
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       type: array
                                   required:
                                     - nodeSelectorTerms
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             podAffinity:
                               properties:
@@ -3440,6 +3629,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -3463,6 +3653,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             items:
                                               type: string
@@ -3506,6 +3697,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -3529,6 +3721,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -3570,6 +3763,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -3593,6 +3787,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             items:
                                               type: string
@@ -3636,6 +3831,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -3659,6 +3855,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -3685,6 +3882,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                         initContainers:
                           items:
@@ -3717,6 +3915,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         fieldRef:
                                           properties:
                                             apiVersion:
@@ -3726,6 +3925,7 @@ spec:
                                           required:
                                             - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resourceFieldRef:
                                           properties:
                                             containerName:
@@ -3741,6 +3941,7 @@ spec:
                                           required:
                                             - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           properties:
                                             key:
@@ -3752,6 +3953,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                   required:
                                     - name
@@ -3767,6 +3969,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       type: string
                                     secretRef:
@@ -3776,6 +3979,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
                               image:
@@ -4067,8 +4271,33 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                items:
+                                  properties:
+                                    resourceName:
+                                      type: string
+                                    restartPolicy:
+                                      type: string
+                                  required:
+                                    - resourceName
+                                    - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -4086,6 +4315,8 @@ spec:
                                       x-kubernetes-int-or-string: true
                                     type: object
                                 type: object
+                              restartPolicy:
+                                type: string
                               securityContext:
                                 properties:
                                   allowPrivilegeEscalation:
@@ -4307,6 +4538,7 @@ spec:
                                         required:
                                           - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -4316,6 +4548,7 @@ spec:
                                         required:
                                           - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -4331,6 +4564,7 @@ spec:
                                         required:
                                           - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -4342,6 +4576,7 @@ spec:
                                         required:
                                           - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                   - name
@@ -4612,6 +4847,18 @@ spec:
                               type: object
                             resources:
                               properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
                                 limits:
                                   additionalProperties:
                                     anyOf:
@@ -4745,6 +4992,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   user:
                                     type: string
                                 required:
@@ -4761,6 +5009,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   volumeID:
                                     type: string
                                 required:
@@ -4791,6 +5040,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               csi:
                                 properties:
                                   driver:
@@ -4802,6 +5052,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   readOnly:
                                     type: boolean
                                   volumeAttributes:
@@ -4828,6 +5079,7 @@ spec:
                                           required:
                                             - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         mode:
                                           format: int32
                                           type: integer
@@ -4848,6 +5100,7 @@ spec:
                                           required:
                                             - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       required:
                                         - path
                                       type: object
@@ -4888,6 +5141,7 @@ spec:
                                               - kind
                                               - name
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           dataSourceRef:
                                             properties:
                                               apiGroup:
@@ -4896,12 +5150,26 @@ spec:
                                                 type: string
                                               name:
                                                 type: string
+                                              namespace:
+                                                type: string
                                             required:
                                               - kind
                                               - name
                                             type: object
                                           resources:
                                             properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                  - name
+                                                x-kubernetes-list-type: map
                                               limits:
                                                 additionalProperties:
                                                   anyOf:
@@ -4942,6 +5210,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           storageClassName:
                                             type: string
                                           volumeMode:
@@ -4988,6 +5257,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 required:
                                   - driver
                                 type: object
@@ -5072,6 +5342,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   targetPortal:
                                     type: string
                                 required:
@@ -5152,6 +5423,7 @@ spec:
                                             optional:
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         downwardAPI:
                                           properties:
                                             items:
@@ -5166,6 +5438,7 @@ spec:
                                                     required:
                                                       - fieldPath
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                   mode:
                                                     format: int32
                                                     type: integer
@@ -5186,6 +5459,7 @@ spec:
                                                     required:
                                                       - resource
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                 required:
                                                   - path
                                                 type: object
@@ -5213,6 +5487,7 @@ spec:
                                             optional:
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
                                           properties:
                                             audience:
@@ -5267,6 +5542,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   user:
                                     type: string
                                 required:
@@ -5288,6 +5564,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   sslEnabled:
                                     type: boolean
                                   storageMode:
@@ -5339,6 +5616,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   volumeName:
                                     type: string
                                   volumeNamespace:
@@ -5363,15 +5641,37 @@ spec:
                           type: array
                       type: object
                   type: object
-                enableInfluxDBProtocol:
-                  type: boolean
                 flownode:
                   properties:
                     config:
                       type: string
+                    logging:
+                      properties:
+                        format:
+                          enum:
+                            - json
+                            - text
+                          type: string
+                        level:
+                          enum:
+                            - info
+                            - error
+                            - warn
+                            - debug
+                          type: string
+                        logsDir:
+                          type: string
+                        onlyLogToStdout:
+                          type: boolean
+                        persistentWithData:
+                          type: boolean
+                      type: object
                     replicas:
                       format: int32
                       minimum: 0
+                      type: integer
+                    rpcPort:
+                      format: int32
                       type: integer
                     template:
                       properties:
@@ -5409,6 +5709,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         fieldRef:
                                           properties:
                                             apiVersion:
@@ -5418,6 +5719,7 @@ spec:
                                           required:
                                             - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resourceFieldRef:
                                           properties:
                                             containerName:
@@ -5433,6 +5735,7 @@ spec:
                                           required:
                                             - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           properties:
                                             key:
@@ -5444,6 +5747,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                   required:
                                     - name
@@ -5459,6 +5763,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       type: string
                                     secretRef:
@@ -5468,6 +5773,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
                               image:
@@ -5759,8 +6065,33 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                items:
+                                  properties:
+                                    resourceName:
+                                      type: string
+                                    restartPolicy:
+                                      type: string
+                                  required:
+                                    - resourceName
+                                    - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -5778,6 +6109,8 @@ spec:
                                       x-kubernetes-int-or-string: true
                                     type: object
                                 type: object
+                              restartPolicy:
+                                type: string
                               securityContext:
                                 properties:
                                   allowPrivilegeEscalation:
@@ -6007,6 +6340,7 @@ spec:
                                               type: object
                                             type: array
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       weight:
                                         format: int32
                                         type: integer
@@ -6053,10 +6387,12 @@ spec:
                                               type: object
                                             type: array
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       type: array
                                   required:
                                     - nodeSelectorTerms
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             podAffinity:
                               properties:
@@ -6088,6 +6424,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -6111,6 +6448,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             items:
                                               type: string
@@ -6154,6 +6492,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -6177,6 +6516,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -6218,6 +6558,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -6241,6 +6582,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             items:
                                               type: string
@@ -6284,6 +6626,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -6307,6 +6650,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -6333,6 +6677,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                         initContainers:
                           items:
@@ -6365,6 +6710,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         fieldRef:
                                           properties:
                                             apiVersion:
@@ -6374,6 +6720,7 @@ spec:
                                           required:
                                             - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resourceFieldRef:
                                           properties:
                                             containerName:
@@ -6389,6 +6736,7 @@ spec:
                                           required:
                                             - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           properties:
                                             key:
@@ -6400,6 +6748,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                   required:
                                     - name
@@ -6415,6 +6764,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       type: string
                                     secretRef:
@@ -6424,6 +6774,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
                               image:
@@ -6715,8 +7066,33 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                items:
+                                  properties:
+                                    resourceName:
+                                      type: string
+                                    restartPolicy:
+                                      type: string
+                                  required:
+                                    - resourceName
+                                    - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -6734,6 +7110,8 @@ spec:
                                       x-kubernetes-int-or-string: true
                                     type: object
                                 type: object
+                              restartPolicy:
+                                type: string
                               securityContext:
                                 properties:
                                   allowPrivilegeEscalation:
@@ -6955,6 +7333,7 @@ spec:
                                         required:
                                           - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -6964,6 +7343,7 @@ spec:
                                         required:
                                           - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -6979,6 +7359,7 @@ spec:
                                         required:
                                           - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -6990,6 +7371,7 @@ spec:
                                         required:
                                           - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                   - name
@@ -7260,6 +7642,18 @@ spec:
                               type: object
                             resources:
                               properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
                                 limits:
                                   additionalProperties:
                                     anyOf:
@@ -7393,6 +7787,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   user:
                                     type: string
                                 required:
@@ -7409,6 +7804,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   volumeID:
                                     type: string
                                 required:
@@ -7439,6 +7835,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               csi:
                                 properties:
                                   driver:
@@ -7450,6 +7847,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   readOnly:
                                     type: boolean
                                   volumeAttributes:
@@ -7476,6 +7874,7 @@ spec:
                                           required:
                                             - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         mode:
                                           format: int32
                                           type: integer
@@ -7496,6 +7895,7 @@ spec:
                                           required:
                                             - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       required:
                                         - path
                                       type: object
@@ -7536,6 +7936,7 @@ spec:
                                               - kind
                                               - name
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           dataSourceRef:
                                             properties:
                                               apiGroup:
@@ -7544,12 +7945,26 @@ spec:
                                                 type: string
                                               name:
                                                 type: string
+                                              namespace:
+                                                type: string
                                             required:
                                               - kind
                                               - name
                                             type: object
                                           resources:
                                             properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                  - name
+                                                x-kubernetes-list-type: map
                                               limits:
                                                 additionalProperties:
                                                   anyOf:
@@ -7590,6 +8005,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           storageClassName:
                                             type: string
                                           volumeMode:
@@ -7636,6 +8052,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 required:
                                   - driver
                                 type: object
@@ -7720,6 +8137,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   targetPortal:
                                     type: string
                                 required:
@@ -7800,6 +8218,7 @@ spec:
                                             optional:
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         downwardAPI:
                                           properties:
                                             items:
@@ -7814,6 +8233,7 @@ spec:
                                                     required:
                                                       - fieldPath
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                   mode:
                                                     format: int32
                                                     type: integer
@@ -7834,6 +8254,7 @@ spec:
                                                     required:
                                                       - resource
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                 required:
                                                   - path
                                                 type: object
@@ -7861,6 +8282,7 @@ spec:
                                             optional:
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
                                           properties:
                                             audience:
@@ -7915,6 +8337,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   user:
                                     type: string
                                 required:
@@ -7936,6 +8359,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   sslEnabled:
                                     type: boolean
                                   storageMode:
@@ -7987,6 +8411,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   volumeName:
                                     type: string
                                   volumeNamespace:
@@ -8015,6 +8440,27 @@ spec:
                   properties:
                     config:
                       type: string
+                    logging:
+                      properties:
+                        format:
+                          enum:
+                            - json
+                            - text
+                          type: string
+                        level:
+                          enum:
+                            - info
+                            - error
+                            - warn
+                            - debug
+                          type: string
+                        logsDir:
+                          type: string
+                        onlyLogToStdout:
+                          type: boolean
+                        persistentWithData:
+                          type: boolean
+                      type: object
                     replicas:
                       format: int32
                       minimum: 0
@@ -8070,6 +8516,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         fieldRef:
                                           properties:
                                             apiVersion:
@@ -8079,6 +8526,7 @@ spec:
                                           required:
                                             - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resourceFieldRef:
                                           properties:
                                             containerName:
@@ -8094,6 +8542,7 @@ spec:
                                           required:
                                             - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           properties:
                                             key:
@@ -8105,6 +8554,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                   required:
                                     - name
@@ -8120,6 +8570,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       type: string
                                     secretRef:
@@ -8129,6 +8580,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
                               image:
@@ -8420,8 +8872,33 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                items:
+                                  properties:
+                                    resourceName:
+                                      type: string
+                                    restartPolicy:
+                                      type: string
+                                  required:
+                                    - resourceName
+                                    - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -8439,6 +8916,8 @@ spec:
                                       x-kubernetes-int-or-string: true
                                     type: object
                                 type: object
+                              restartPolicy:
+                                type: string
                               securityContext:
                                 properties:
                                   allowPrivilegeEscalation:
@@ -8668,6 +9147,7 @@ spec:
                                               type: object
                                             type: array
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       weight:
                                         format: int32
                                         type: integer
@@ -8714,10 +9194,12 @@ spec:
                                               type: object
                                             type: array
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       type: array
                                   required:
                                     - nodeSelectorTerms
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             podAffinity:
                               properties:
@@ -8749,6 +9231,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -8772,6 +9255,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             items:
                                               type: string
@@ -8815,6 +9299,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -8838,6 +9323,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -8879,6 +9365,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -8902,6 +9389,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             items:
                                               type: string
@@ -8945,6 +9433,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -8968,6 +9457,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -8994,6 +9484,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                         initContainers:
                           items:
@@ -9026,6 +9517,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         fieldRef:
                                           properties:
                                             apiVersion:
@@ -9035,6 +9527,7 @@ spec:
                                           required:
                                             - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resourceFieldRef:
                                           properties:
                                             containerName:
@@ -9050,6 +9543,7 @@ spec:
                                           required:
                                             - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           properties:
                                             key:
@@ -9061,6 +9555,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                   required:
                                     - name
@@ -9076,6 +9571,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       type: string
                                     secretRef:
@@ -9085,6 +9581,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
                               image:
@@ -9376,8 +9873,33 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                items:
+                                  properties:
+                                    resourceName:
+                                      type: string
+                                    restartPolicy:
+                                      type: string
+                                  required:
+                                    - resourceName
+                                    - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -9395,6 +9917,8 @@ spec:
                                       x-kubernetes-int-or-string: true
                                     type: object
                                 type: object
+                              restartPolicy:
+                                type: string
                               securityContext:
                                 properties:
                                   allowPrivilegeEscalation:
@@ -9616,6 +10140,7 @@ spec:
                                         required:
                                           - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -9625,6 +10150,7 @@ spec:
                                         required:
                                           - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -9640,6 +10166,7 @@ spec:
                                         required:
                                           - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -9651,6 +10178,7 @@ spec:
                                         required:
                                           - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                   - name
@@ -9921,6 +10449,18 @@ spec:
                               type: object
                             resources:
                               properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
                                 limits:
                                   additionalProperties:
                                     anyOf:
@@ -10054,6 +10594,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   user:
                                     type: string
                                 required:
@@ -10070,6 +10611,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   volumeID:
                                     type: string
                                 required:
@@ -10100,6 +10642,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               csi:
                                 properties:
                                   driver:
@@ -10111,6 +10654,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   readOnly:
                                     type: boolean
                                   volumeAttributes:
@@ -10137,6 +10681,7 @@ spec:
                                           required:
                                             - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         mode:
                                           format: int32
                                           type: integer
@@ -10157,6 +10702,7 @@ spec:
                                           required:
                                             - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       required:
                                         - path
                                       type: object
@@ -10197,6 +10743,7 @@ spec:
                                               - kind
                                               - name
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           dataSourceRef:
                                             properties:
                                               apiGroup:
@@ -10205,12 +10752,26 @@ spec:
                                                 type: string
                                               name:
                                                 type: string
+                                              namespace:
+                                                type: string
                                             required:
                                               - kind
                                               - name
                                             type: object
                                           resources:
                                             properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                  - name
+                                                x-kubernetes-list-type: map
                                               limits:
                                                 additionalProperties:
                                                   anyOf:
@@ -10251,6 +10812,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           storageClassName:
                                             type: string
                                           volumeMode:
@@ -10297,6 +10859,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 required:
                                   - driver
                                 type: object
@@ -10381,6 +10944,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   targetPortal:
                                     type: string
                                 required:
@@ -10461,6 +11025,7 @@ spec:
                                             optional:
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         downwardAPI:
                                           properties:
                                             items:
@@ -10475,6 +11040,7 @@ spec:
                                                     required:
                                                       - fieldPath
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                   mode:
                                                     format: int32
                                                     type: integer
@@ -10495,6 +11061,7 @@ spec:
                                                     required:
                                                       - resource
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                 required:
                                                   - path
                                                 type: object
@@ -10522,6 +11089,7 @@ spec:
                                             optional:
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
                                           properties:
                                             audience:
@@ -10576,6 +11144,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   user:
                                     type: string
                                 required:
@@ -10597,6 +11166,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   sslEnabled:
                                     type: boolean
                                   storageMode:
@@ -10648,6 +11218,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   volumeName:
                                     type: string
                                   volumeNamespace:
@@ -10675,18 +11246,38 @@ spec:
                       properties:
                         secretName:
                           type: string
+                      required:
+                        - secretName
                       type: object
                   type: object
-                grpcServicePort:
-                  format: int32
-                  type: integer
-                httpServicePort:
+                httpPort:
                   format: int32
                   type: integer
                 initializer:
                   properties:
                     image:
                       type: string
+                  type: object
+                logging:
+                  properties:
+                    format:
+                      enum:
+                        - json
+                        - text
+                      type: string
+                    level:
+                      enum:
+                        - info
+                        - error
+                        - warn
+                        - debug
+                      type: string
+                    logsDir:
+                      type: string
+                    onlyLogToStdout:
+                      type: boolean
+                    persistentWithData:
+                      type: boolean
                   type: object
                 meta:
                   properties:
@@ -10700,11 +11291,35 @@ spec:
                       items:
                         type: string
                       type: array
+                    httpPort:
+                      format: int32
+                      type: integer
+                    logging:
+                      properties:
+                        format:
+                          enum:
+                            - json
+                            - text
+                          type: string
+                        level:
+                          enum:
+                            - info
+                            - error
+                            - warn
+                            - debug
+                          type: string
+                        logsDir:
+                          type: string
+                        onlyLogToStdout:
+                          type: boolean
+                        persistentWithData:
+                          type: boolean
+                      type: object
                     replicas:
                       format: int32
                       minimum: 0
                       type: integer
-                    servicePort:
+                    rpcPort:
                       format: int32
                       type: integer
                     storeKeyPrefix:
@@ -10745,6 +11360,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         fieldRef:
                                           properties:
                                             apiVersion:
@@ -10754,6 +11370,7 @@ spec:
                                           required:
                                             - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resourceFieldRef:
                                           properties:
                                             containerName:
@@ -10769,6 +11386,7 @@ spec:
                                           required:
                                             - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           properties:
                                             key:
@@ -10780,6 +11398,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                   required:
                                     - name
@@ -10795,6 +11414,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       type: string
                                     secretRef:
@@ -10804,6 +11424,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
                               image:
@@ -11095,8 +11716,33 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                items:
+                                  properties:
+                                    resourceName:
+                                      type: string
+                                    restartPolicy:
+                                      type: string
+                                  required:
+                                    - resourceName
+                                    - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -11114,6 +11760,8 @@ spec:
                                       x-kubernetes-int-or-string: true
                                     type: object
                                 type: object
+                              restartPolicy:
+                                type: string
                               securityContext:
                                 properties:
                                   allowPrivilegeEscalation:
@@ -11343,6 +11991,7 @@ spec:
                                               type: object
                                             type: array
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       weight:
                                         format: int32
                                         type: integer
@@ -11389,10 +12038,12 @@ spec:
                                               type: object
                                             type: array
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       type: array
                                   required:
                                     - nodeSelectorTerms
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             podAffinity:
                               properties:
@@ -11424,6 +12075,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -11447,6 +12099,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             items:
                                               type: string
@@ -11490,6 +12143,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -11513,6 +12167,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -11554,6 +12209,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -11577,6 +12233,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             items:
                                               type: string
@@ -11620,6 +12277,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -11643,6 +12301,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -11669,6 +12328,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                         initContainers:
                           items:
@@ -11701,6 +12361,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         fieldRef:
                                           properties:
                                             apiVersion:
@@ -11710,6 +12371,7 @@ spec:
                                           required:
                                             - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resourceFieldRef:
                                           properties:
                                             containerName:
@@ -11725,6 +12387,7 @@ spec:
                                           required:
                                             - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           properties:
                                             key:
@@ -11736,6 +12399,7 @@ spec:
                                           required:
                                             - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                   required:
                                     - name
@@ -11751,6 +12415,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       type: string
                                     secretRef:
@@ -11760,6 +12425,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
                               image:
@@ -12051,8 +12717,33 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                items:
+                                  properties:
+                                    resourceName:
+                                      type: string
+                                    restartPolicy:
+                                      type: string
+                                  required:
+                                    - resourceName
+                                    - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -12070,6 +12761,8 @@ spec:
                                       x-kubernetes-int-or-string: true
                                     type: object
                                 type: object
+                              restartPolicy:
+                                type: string
                               securityContext:
                                 properties:
                                   allowPrivilegeEscalation:
@@ -12291,6 +12984,7 @@ spec:
                                         required:
                                           - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -12300,6 +12994,7 @@ spec:
                                         required:
                                           - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -12315,6 +13010,7 @@ spec:
                                         required:
                                           - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -12326,6 +13022,7 @@ spec:
                                         required:
                                           - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                   - name
@@ -12596,6 +13293,18 @@ spec:
                               type: object
                             resources:
                               properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
                                 limits:
                                   additionalProperties:
                                     anyOf:
@@ -12729,6 +13438,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   user:
                                     type: string
                                 required:
@@ -12745,6 +13455,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   volumeID:
                                     type: string
                                 required:
@@ -12775,6 +13486,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               csi:
                                 properties:
                                   driver:
@@ -12786,6 +13498,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   readOnly:
                                     type: boolean
                                   volumeAttributes:
@@ -12812,6 +13525,7 @@ spec:
                                           required:
                                             - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         mode:
                                           format: int32
                                           type: integer
@@ -12832,6 +13546,7 @@ spec:
                                           required:
                                             - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       required:
                                         - path
                                       type: object
@@ -12872,6 +13587,7 @@ spec:
                                               - kind
                                               - name
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           dataSourceRef:
                                             properties:
                                               apiGroup:
@@ -12880,12 +13596,26 @@ spec:
                                                 type: string
                                               name:
                                                 type: string
+                                              namespace:
+                                                type: string
                                             required:
                                               - kind
                                               - name
                                             type: object
                                           resources:
                                             properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                  - name
+                                                x-kubernetes-list-type: map
                                               limits:
                                                 additionalProperties:
                                                   anyOf:
@@ -12926,6 +13656,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           storageClassName:
                                             type: string
                                           volumeMode:
@@ -12972,6 +13703,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 required:
                                   - driver
                                 type: object
@@ -13056,6 +13788,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   targetPortal:
                                     type: string
                                 required:
@@ -13136,6 +13869,7 @@ spec:
                                             optional:
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         downwardAPI:
                                           properties:
                                             items:
@@ -13150,6 +13884,7 @@ spec:
                                                     required:
                                                       - fieldPath
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                   mode:
                                                     format: int32
                                                     type: integer
@@ -13170,6 +13905,7 @@ spec:
                                                     required:
                                                       - resource
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                 required:
                                                   - path
                                                 type: object
@@ -13197,6 +13933,7 @@ spec:
                                             optional:
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
                                           properties:
                                             audience:
@@ -13251,6 +13988,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   user:
                                     type: string
                                 required:
@@ -13272,6 +14010,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   sslEnabled:
                                     type: boolean
                                   storageMode:
@@ -13323,6 +14062,7 @@ spec:
                                       name:
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   volumeName:
                                     type: string
                                   volumeNamespace:
@@ -13346,16 +14086,36 @@ spec:
                             type: object
                           type: array
                       type: object
+                  required:
+                    - etcdEndpoints
                   type: object
-                mysqlServicePort:
+                mysqlPort:
                   format: int32
                   type: integer
                 objectStorage:
                   properties:
-                    cacheCapacity:
-                      type: string
-                    cachePath:
-                      type: string
+                    cache:
+                      properties:
+                        cacheCapacity:
+                          type: string
+                        fs:
+                          properties:
+                            mountPath:
+                              type: string
+                            name:
+                              type: string
+                            storageClassName:
+                              type: string
+                            storageRetainPolicy:
+                              enum:
+                                - Retain
+                                - Delete
+                              type: string
+                            storageSize:
+                              pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
+                              type: string
+                          type: object
+                      type: object
                     gcs:
                       properties:
                         bucket:
@@ -13368,6 +14128,9 @@ spec:
                           type: string
                         secretName:
                           type: string
+                      required:
+                        - bucket
+                        - root
                       type: object
                     oss:
                       properties:
@@ -13381,6 +14144,10 @@ spec:
                           type: string
                         secretName:
                           type: string
+                      required:
+                        - bucket
+                        - region
+                        - root
                       type: object
                     s3:
                       properties:
@@ -13394,9 +14161,13 @@ spec:
                           type: string
                         secretName:
                           type: string
+                      required:
+                        - bucket
+                        - region
+                        - root
                       type: object
                   type: object
-                postgresServicePort:
+                postgreSQLPort:
                   format: int32
                   type: integer
                 prometheusMonitor:
@@ -13409,8 +14180,15 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                  required:
+                    - enabled
                   type: object
-                remoteWal:
+                rpcPort:
+                  format: int32
+                  type: integer
+                version:
+                  type: string
+                wal:
                   properties:
                     kafka:
                       properties:
@@ -13418,10 +14196,34 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                        - brokerEndpoints
+                      type: object
+                    raftEngine:
+                      properties:
+                        fs:
+                          properties:
+                            mountPath:
+                              type: string
+                            name:
+                              type: string
+                            storageClassName:
+                              type: string
+                            storageRetainPolicy:
+                              enum:
+                                - Retain
+                                - Delete
+                              type: string
+                            storageSize:
+                              pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
+                              type: string
+                          type: object
                       type: object
                   type: object
-                version:
-                  type: string
+              required:
+                - datanode
+                - frontend
+                - meta
               type: object
             status:
               properties:

--- a/charts/greptimedb-operator/templates/crds/crd-greptimedbstandalone.yaml
+++ b/charts/greptimedb-operator/templates/crds/crd-greptimedbstandalone.yaml
@@ -83,6 +83,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     fieldRef:
                                       properties:
                                         apiVersion:
@@ -92,6 +93,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     resourceFieldRef:
                                       properties:
                                         containerName:
@@ -107,6 +109,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     secretKeyRef:
                                       properties:
                                         key:
@@ -118,6 +121,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                               required:
                                 - name
@@ -133,6 +137,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 prefix:
                                   type: string
                                 secretRef:
@@ -142,6 +147,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             type: array
                           image:
@@ -433,8 +439,33 @@ spec:
                                 format: int32
                                 type: integer
                             type: object
+                          resizePolicy:
+                            items:
+                              properties:
+                                resourceName:
+                                  type: string
+                                restartPolicy:
+                                  type: string
+                              required:
+                                - resourceName
+                                - restartPolicy
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
                           resources:
                             properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
                               limits:
                                 additionalProperties:
                                   anyOf:
@@ -452,6 +483,8 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
+                          restartPolicy:
+                            type: string
                           securityContext:
                             properties:
                               allowPrivilegeEscalation:
@@ -681,6 +714,7 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   weight:
                                     format: int32
                                     type: integer
@@ -727,10 +761,12 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   type: array
                               required:
                                 - nodeSelectorTerms
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
                           properties:
@@ -762,6 +798,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -785,6 +822,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -828,6 +866,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -851,6 +890,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     items:
                                       type: string
@@ -892,6 +932,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -915,6 +956,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -958,6 +1000,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -981,6 +1024,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     items:
                                       type: string
@@ -1007,6 +1051,7 @@ spec:
                           name:
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       type: array
                     initContainers:
                       items:
@@ -1039,6 +1084,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     fieldRef:
                                       properties:
                                         apiVersion:
@@ -1048,6 +1094,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     resourceFieldRef:
                                       properties:
                                         containerName:
@@ -1063,6 +1110,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     secretKeyRef:
                                       properties:
                                         key:
@@ -1074,6 +1122,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                               required:
                                 - name
@@ -1089,6 +1138,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 prefix:
                                   type: string
                                 secretRef:
@@ -1098,6 +1148,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             type: array
                           image:
@@ -1389,8 +1440,33 @@ spec:
                                 format: int32
                                 type: integer
                             type: object
+                          resizePolicy:
+                            items:
+                              properties:
+                                resourceName:
+                                  type: string
+                                restartPolicy:
+                                  type: string
+                              required:
+                                - resourceName
+                                - restartPolicy
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
                           resources:
                             properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
                               limits:
                                 additionalProperties:
                                   anyOf:
@@ -1408,6 +1484,8 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
+                          restartPolicy:
+                            type: string
                           securityContext:
                             properties:
                               allowPrivilegeEscalation:
@@ -1629,6 +1707,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     properties:
                                       apiVersion:
@@ -1638,6 +1717,7 @@ spec:
                                     required:
                                       - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -1653,6 +1733,7 @@ spec:
                                     required:
                                       - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     properties:
                                       key:
@@ -1664,6 +1745,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                               - name
@@ -1934,6 +2016,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -2067,6 +2161,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               user:
                                 type: string
                             required:
@@ -2083,6 +2178,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               volumeID:
                                 type: string
                             required:
@@ -2113,6 +2209,7 @@ spec:
                               optional:
                                 type: boolean
                             type: object
+                            x-kubernetes-map-type: atomic
                           csi:
                             properties:
                               driver:
@@ -2124,6 +2221,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               readOnly:
                                 type: boolean
                               volumeAttributes:
@@ -2150,6 +2248,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     mode:
                                       format: int32
                                       type: integer
@@ -2170,6 +2269,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   required:
                                     - path
                                   type: object
@@ -2210,6 +2310,7 @@ spec:
                                           - kind
                                           - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       dataSourceRef:
                                         properties:
                                           apiGroup:
@@ -2218,12 +2319,26 @@ spec:
                                             type: string
                                           name:
                                             type: string
+                                          namespace:
+                                            type: string
                                         required:
                                           - kind
                                           - name
                                         type: object
                                       resources:
                                         properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
                                           limits:
                                             additionalProperties:
                                               anyOf:
@@ -2264,6 +2379,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       storageClassName:
                                         type: string
                                       volumeMode:
@@ -2310,6 +2426,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                             required:
                               - driver
                             type: object
@@ -2394,6 +2511,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               targetPortal:
                                 type: string
                             required:
@@ -2474,6 +2592,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     downwardAPI:
                                       properties:
                                         items:
@@ -2488,6 +2607,7 @@ spec:
                                                 required:
                                                   - fieldPath
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               mode:
                                                 format: int32
                                                 type: integer
@@ -2508,6 +2628,7 @@ spec:
                                                 required:
                                                   - resource
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                             required:
                                               - path
                                             type: object
@@ -2535,6 +2656,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     serviceAccountToken:
                                       properties:
                                         audience:
@@ -2589,6 +2711,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               user:
                                 type: string
                             required:
@@ -2610,6 +2733,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               sslEnabled:
                                 type: boolean
                               storageMode:
@@ -2661,6 +2785,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               volumeName:
                                 type: string
                               volumeNamespace:
@@ -2686,12 +2811,29 @@ spec:
                   type: object
                 config:
                   type: string
-                enableInfluxDBProtocol:
-                  type: boolean
-                grpcServicePort:
-                  format: int32
-                  type: integer
-                httpServicePort:
+                datanodeStorage:
+                  properties:
+                    dataHome:
+                      type: string
+                    fs:
+                      properties:
+                        mountPath:
+                          type: string
+                        name:
+                          type: string
+                        storageClassName:
+                          type: string
+                        storageRetainPolicy:
+                          enum:
+                            - Retain
+                            - Delete
+                          type: string
+                        storageSize:
+                          pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
+                          type: string
+                      type: object
+                  type: object
+                httpPort:
                   format: int32
                   type: integer
                 initializer:
@@ -2699,36 +2841,54 @@ spec:
                     image:
                       type: string
                   type: object
-                localStorage:
+                logging:
                   properties:
-                    dataHome:
-                      type: string
-                    mountPath:
-                      type: string
-                    name:
-                      type: string
-                    storageClassName:
-                      type: string
-                    storageRetainPolicy:
+                    format:
                       enum:
-                        - Retain
-                        - Delete
+                        - json
+                        - text
                       type: string
-                    storageSize:
-                      pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
+                    level:
+                      enum:
+                        - info
+                        - error
+                        - warn
+                        - debug
                       type: string
-                    walDir:
+                    logsDir:
                       type: string
+                    onlyLogToStdout:
+                      type: boolean
+                    persistentWithData:
+                      type: boolean
                   type: object
-                mysqlServicePort:
+                mysqlPort:
                   format: int32
                   type: integer
                 objectStorage:
                   properties:
-                    cacheCapacity:
-                      type: string
-                    cachePath:
-                      type: string
+                    cache:
+                      properties:
+                        cacheCapacity:
+                          type: string
+                        fs:
+                          properties:
+                            mountPath:
+                              type: string
+                            name:
+                              type: string
+                            storageClassName:
+                              type: string
+                            storageRetainPolicy:
+                              enum:
+                                - Retain
+                                - Delete
+                              type: string
+                            storageSize:
+                              pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
+                              type: string
+                          type: object
+                      type: object
                     gcs:
                       properties:
                         bucket:
@@ -2741,6 +2901,9 @@ spec:
                           type: string
                         secretName:
                           type: string
+                      required:
+                        - bucket
+                        - root
                       type: object
                     oss:
                       properties:
@@ -2754,6 +2917,10 @@ spec:
                           type: string
                         secretName:
                           type: string
+                      required:
+                        - bucket
+                        - region
+                        - root
                       type: object
                     s3:
                       properties:
@@ -2767,9 +2934,13 @@ spec:
                           type: string
                         secretName:
                           type: string
+                      required:
+                        - bucket
+                        - region
+                        - root
                       type: object
                   type: object
-                postgresServicePort:
+                postgreSQLPort:
                   format: int32
                   type: integer
                 prometheusMonitor:
@@ -2782,17 +2953,12 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                  required:
+                    - enabled
                   type: object
-                remoteWal:
-                  properties:
-                    kafka:
-                      properties:
-                        brokerEndpoints:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                  type: object
+                rpcPort:
+                  format: int32
+                  type: integer
                 service:
                   properties:
                     annotations:
@@ -2812,9 +2978,43 @@ spec:
                   properties:
                     secretName:
                       type: string
+                  required:
+                    - secretName
                   type: object
                 version:
                   type: string
+                wal:
+                  properties:
+                    kafka:
+                      properties:
+                        brokerEndpoints:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - brokerEndpoints
+                      type: object
+                    raftEngine:
+                      properties:
+                        fs:
+                          properties:
+                            mountPath:
+                              type: string
+                            name:
+                              type: string
+                            storageClassName:
+                              type: string
+                            storageRetainPolicy:
+                              enum:
+                                - Retain
+                                - Delete
+                              type: string
+                            storageSize:
+                              pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
+                              type: string
+                          type: object
+                      type: object
+                  type: object
               type: object
             status:
               properties:

--- a/scripts/e2e/greptimedb-cluster.sh
+++ b/scripts/e2e/greptimedb-cluster.sh
@@ -84,14 +84,16 @@ function deploy_greptimedb_operator() {
 }
 
 function deploy_etcd() {
-  helm upgrade --install etcd oci://registry-1.docker.io/bitnamicharts/etcd \
+  helm upgrade --install etcd \
+    oci://registry-1.docker.io/bitnamicharts/etcd \
     --set replicaCount=1 \
     --set auth.rbac.create=false \
     --set auth.rbac.token.enabled=false \
-    -n default
+    --create-namespace \
+    -n etcd-cluster
 
   # Wait for etcd to be ready
-  kubectl rollout status --timeout=120s statefulset/etcd -n default
+  kubectl rollout status --timeout=120s statefulset/etcd -n etcd-cluster
 }
 
 function mysql_test_greptimedb_cluster() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated `greptimedb-cluster` Helm chart to version 0.2.13 with new configuration options for `datanode` and `meta` components.
	- Introduced `mountPath` for `datanode.storage` and updated `etcdEndpoints`.
	- Enhanced `greptimedb-operator` Helm chart to version 0.2.4, indicating a stable release.

- **Bug Fixes**
	- Deprecated `walDir` in favor of the new `mountPath` for clarity.

- **Documentation**
	- Updated README files to reflect version changes and new configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->