### PR TITLE
chore: bump operator version

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.2.18
+version: 0.2.19
 appVersion: 0.9.4
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.2.18](https://img.shields.io/badge/Version-0.2.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.4](https://img.shields.io/badge/AppVersion-0.9.4-informational?style=flat-square)
+![Version: 0.2.19](https://img.shields.io/badge/Version-0.2.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.4](https://img.shields.io/badge/AppVersion-0.9.4-informational?style=flat-square)
 
 ## Source Code
 
@@ -181,7 +181,7 @@ helm uninstall mycluster -n default
 | image.tag | string | `"v0.9.4"` | The image tag |
 | initializer.registry | string | `"docker.io"` | Initializer image registry |
 | initializer.repository | string | `"greptime/greptimedb-initializer"` | Initializer image repository |
-| initializer.tag | string | `"v0.1.1"` | Initializer image tag |
+| initializer.tag | string | `"v0.1.2"` | Initializer image tag |
 | logging | object | `{"format":"text","level":"info","logsDir":"/data/greptimedb/logs","onlyLogToStdout":false,"persistentWithData":false}` | Global logging configuration |
 | logging.format | string | `"text"` | The log format for greptimedb, only support "json" and "text" |
 | logging.level | string | `"info"` | The log level for greptimedb, only support "debug", "info", "warn", "debug" |
@@ -214,15 +214,15 @@ helm uninstall mycluster -n default
 | meta.podTemplate.volumes | list | `[]` | The pod volumes |
 | meta.replicas | int | `1` | Meta replicas |
 | meta.storeKeyPrefix | string | `""` | Meta will store data with this key prefix |
-| monitoring | object | `{"enabled":false,"logsCollection":{"pipeline":{"data":""}},"standalone":{},"vector":{"registry":"docker.io","repository":"timberio/vector","resource":{"limits":{"cpu":"50m","memory":"64Mi"},"requests":{"cpu":"50m","memory":"64Mi"}},"tag":"nightly-alpine"}}` | The monitoring bootstrap configuration |
+| monitoring | object | `{"enabled":false,"logsCollection":{"pipeline":{"data":""}},"standalone":{},"vector":{"registry":"docker.io","repository":"timberio/vector","resources":{"limits":{"cpu":"50m","memory":"64Mi"},"requests":{"cpu":"50m","memory":"64Mi"}},"tag":"nightly-alpine"}}` | The monitoring bootstrap configuration |
 | monitoring.enabled | bool | `false` | Enable monitoring |
 | monitoring.logsCollection | object | `{"pipeline":{"data":""}}` | Configure the logs collection |
 | monitoring.logsCollection.pipeline | object | `{"data":""}` | The greptimedb pipeline for logs collection |
 | monitoring.standalone | object | `{}` | Configure the standalone instance for storing monitoring data |
-| monitoring.vector | object | `{"registry":"docker.io","repository":"timberio/vector","resource":{"limits":{"cpu":"50m","memory":"64Mi"},"requests":{"cpu":"50m","memory":"64Mi"}},"tag":"nightly-alpine"}` | Configure vector for logs and metrics collection. |
+| monitoring.vector | object | `{"registry":"docker.io","repository":"timberio/vector","resources":{"limits":{"cpu":"50m","memory":"64Mi"},"requests":{"cpu":"50m","memory":"64Mi"}},"tag":"nightly-alpine"}` | Configure vector for logs and metrics collection. |
 | monitoring.vector.registry | string | `"docker.io"` | vector image registry |
 | monitoring.vector.repository | string | `"timberio/vector"` | vector image repository |
-| monitoring.vector.resource | object | `{"limits":{"cpu":"50m","memory":"64Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | vector resource |
+| monitoring.vector.resources | object | `{"limits":{"cpu":"50m","memory":"64Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | vector resource |
 | monitoring.vector.tag | string | `"nightly-alpine"` | vector image tag |
 | mysqlServicePort | int | `4002` | GreptimeDB mysql service port |
 | objectStorage | object | `{"gcs":{},"oss":{},"s3":{}}` | Configure to object storage |

--- a/charts/greptimedb-cluster/templates/cluster.yaml
+++ b/charts/greptimedb-cluster/templates/cluster.yaml
@@ -449,7 +449,7 @@ spec:
     vector:
       image: '{{ .Values.monitoring.vector.registry }}/{{ .Values.monitoring.vector.repository }}:{{ .Values.monitoring.vector.tag }}'
       {{- if .Values.monitoring.vector.resource }}
-      resource: {{- toYaml .Values.monitoring.vector.resource | nindent 8 }}
+      resources: {{- toYaml .Values.monitoring.vector.resource | nindent 8 }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -14,7 +14,7 @@ initializer:
   # -- Initializer image repository
   repository: greptime/greptimedb-initializer
   # -- Initializer image tag
-  tag: v0.1.1
+  tag: v0.1.2
 
 base:
   # -- The pod template for base
@@ -627,7 +627,7 @@ monitoring:
     tag: nightly-alpine
 
     # -- vector resource
-    resource:
+    resources:
       requests:
         cpu: "50m"
         memory: "64Mi"

--- a/charts/greptimedb-operator/Chart.yaml
+++ b/charts/greptimedb-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 kubeVersion: ">=1.18.0-0"
 description: The greptimedb-operator Helm chart for Kubernetes.
 name: greptimedb-operator
-appVersion: 0.1.1
-version: 0.2.6
+appVersion: 0.1.2
+version: 0.2.7
 type: application
 home: https://github.com/GreptimeTeam/greptimedb-operator
 sources:

--- a/charts/greptimedb-operator/README.md
+++ b/charts/greptimedb-operator/README.md
@@ -2,7 +2,7 @@
 
 The greptimedb-operator Helm chart for Kubernetes.
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.2](https://img.shields.io/badge/AppVersion-0.1.2-informational?style=flat-square)
 
 ## Source Code
 

--- a/charts/greptimedb-operator/templates/crds/crd-greptimedbcluster.yaml
+++ b/charts/greptimedb-operator/templates/crds/crd-greptimedbcluster.yaml
@@ -17116,7 +17116,7 @@ spec:
                       properties:
                         image:
                           type: string
-                        resource:
+                        resources:
                           properties:
                             claims:
                               items:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version numbers for both `greptimedb-cluster` and `greptimedb-operator` Helm charts.
	- Enhanced resource management capabilities in the `GreptimeDBCluster` Custom Resource Definition (CRD).

- **Bug Fixes**
	- Corrected naming inconsistencies in configuration fields for monitoring vector resources.

- **Documentation**
	- Updated README files to reflect new version numbers and changes in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->