### PR TITLE
chore(greptimedb-cluster): add port and path to the probe

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.2.21
+version: 0.2.22
 appVersion: 0.9.5
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.2.21](https://img.shields.io/badge/Version-0.2.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
+![Version: 0.2.22](https://img.shields.io/badge/Version-0.2.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
 
 ## Source Code
 

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -43,7 +43,12 @@ base:
 
       # -- The config for readiness probe of the main container
       readinessProbe: {}
-#        # -- The initial delay seconds for the readiness probe.
+#        httpGet:
+#        # -- Path to access on the HTTP server
+#          path: /health
+#        # -- Name or number of the port to access on the container
+#          port: 4000
+#        # -- The initial delay seconds for the readiness probe
 #        initialDelaySeconds: 5
 #        # -- The timeout seconds for the readiness probe
 #        timeoutSeconds: 1
@@ -56,6 +61,11 @@ base:
 
       # -- The config for liveness probe of the main container
       livenessProbe: {}
+#        httpGet:
+#        # -- Path to access on the HTTP server
+#          path: /health
+#        # -- Name or number of the port to access on the container
+#          port: 4000
 #        # -- The initial delay seconds for the readiness probe.
 #        initialDelaySeconds: 5
 #        # -- The timeout seconds for the readiness probe
@@ -123,6 +133,11 @@ frontend:
 
       # -- The config for readiness probe of the main container
       readinessProbe: {}
+#        httpGet:
+#        # -- Path to access on the HTTP server
+#          path: /health
+#        # -- Name or number of the port to access on the container
+#          port: 4000
 #        # -- The initial delay seconds for the readiness probe.
 #        initialDelaySeconds: 5
 #        # -- The timeout seconds for the readiness probe
@@ -136,6 +151,11 @@ frontend:
 
       # -- The config for liveness probe of the main container
       livenessProbe: {}
+#        httpGet:
+#        # -- Path to access on the HTTP server
+#          path: /health
+#        # -- Name or number of the port to access on the container
+#          port: 4000
 #        # -- The initial delay seconds for the readiness probe.
 #        initialDelaySeconds: 5
 #        # -- The timeout seconds for the readiness probe
@@ -234,6 +254,11 @@ meta:
 
       # -- The config for readiness probe of the main container
       readinessProbe: {}
+#        httpGet:
+#        # -- Path to access on the HTTP server
+#          path: /health
+#        # -- Name or number of the port to access on the container
+#          port: 4000
 #        # -- The initial delay seconds for the readiness probe.
 #        initialDelaySeconds: 5
 #        # -- The timeout seconds for the readiness probe
@@ -247,6 +272,11 @@ meta:
 
       # -- The config for liveness probe of the main container
       livenessProbe: {}
+#        httpGet:
+#        # -- Path to access on the HTTP server
+#          path: /health
+#        # -- Name or number of the port to access on the container
+#          port: 4000
 #        # -- The initial delay seconds for the readiness probe.
 #        initialDelaySeconds: 5
 #        # -- The timeout seconds for the readiness probe
@@ -347,6 +377,11 @@ datanode:
 
       # -- The config for readiness probe of the main container
       readinessProbe: {}
+#        httpGet:
+#        # -- Path to access on the HTTP server
+#          path: /health
+#        # -- Name or number of the port to access on the container
+#          port: 4000
 #        # -- The initial delay seconds for the readiness probe.
 #        initialDelaySeconds: 5
 #        # -- The timeout seconds for the readiness probe
@@ -360,6 +395,11 @@ datanode:
 
       # -- The config for liveness probe of the main container
       livenessProbe: {}
+#        httpGet:
+#        # -- Path to access on the HTTP server
+#          path: /health
+#        # -- Name or number of the port to access on the container
+#          port: 4000
 #        # -- The initial delay seconds for the readiness probe.
 #        initialDelaySeconds: 5
 #        # -- The timeout seconds for the readiness probe
@@ -487,6 +527,11 @@ flownode:
 
       # -- The config for readiness probe of the main container
       readinessProbe: {}
+#        httpGet:
+#        # -- Path to access on the HTTP server
+#          path: /health
+#        # -- Name or number of the port to access on the container
+#          port: 4000
 #        # -- The initial delay seconds for the readiness probe.
 #        initialDelaySeconds: 5
 #        # -- The timeout seconds for the readiness probe
@@ -500,6 +545,11 @@ flownode:
 
       # -- The config for liveness probe of the main container
       livenessProbe: {}
+#        httpGet:
+#        # -- Path to access on the HTTP server
+#          path: /health
+#        # -- Name or number of the port to access on the container
+#          port: 4000
 #        # -- The initial delay seconds for the readiness probe.
 #        initialDelaySeconds: 5
 #        # -- The timeout seconds for the readiness probe


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version of the `greptimedb-cluster` Helm chart to `0.2.22`.
	- Added commented-out configuration options for readiness and liveness probes in the YAML file, enhancing configurability.
  
- **Documentation**
	- Updated version number in the `README.md` file to reflect the new chart version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->