### PR TITLE
refactor(greptimedb-standalone): Refactor the object storage configuration to make it simplify

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.2.22
+version: 0.2.23
 appVersion: 0.9.5
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.2.22](https://img.shields.io/badge/Version-0.2.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
+![Version: 0.2.23](https://img.shields.io/badge/Version-0.2.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
 
 ## Source Code
 

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -602,10 +602,16 @@ prometheusMonitor:
 # -- Configure to object storage
 objectStorage:
 #  credentials:
+#    secretName: ""
+
+#    # AWS or AliCloud cloudProvider accessKeyID and secretAccessKey
 #    accessKeyId: "you-should-set-the-access-key-id-here"
 #    secretAccessKey: "you-should-set-the-secret-access-key-here"
+
+#    # GCP cloudProvider serviceAccountKey JSON-formatted base64 value
 #    serviceAccountKey: "you-should-set-the-base64-service-account-key-here"
-#    secretName: ""
+
+#    # Set the existing secret to get the key's of cloudProvider
 #    existingSecretName: ""
 
   # configure to use s3 storage.
@@ -629,7 +635,7 @@ objectStorage:
   # configure to use gcs storage
   gcs: {}
   #  bucket: "bucket-name"
-  #  Scope: "" # example: "https://www.googleapis.com/auth/devstorage.read_write"
+  #  scope: "" # example: "https://www.googleapis.com/auth/devstorage.read_write"
 
   #  # The data directory in gcs will be: 'gcs://<bucket>/<root>/data/...'.
   #  root: "mycluster"

--- a/charts/greptimedb-standalone/Chart.yaml
+++ b/charts/greptimedb-standalone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-standalone
 description: A Helm chart for deploying standalone greptimedb
 type: application
-version: 0.1.24
+version: 0.1.25
 appVersion: 0.9.5
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying standalone greptimedb
 
-![Version: 0.1.24](https://img.shields.io/badge/Version-0.1.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
+![Version: 0.1.25](https://img.shields.io/badge/Version-0.1.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
 
 ## Source Code
 - https://github.com/GreptimeTeam/greptimedb
@@ -72,7 +72,7 @@ helm uninstall greptimedb-standalone -n default
 | mysqlServicePort | int | `4002` | GreptimeDB mysql service port |
 | nameOverride | string | `""` | Overrides the chart's name |
 | nodeSelector | object | `{}` | NodeSelector to apply pod |
-| objectStorage | object | `{"oss":{},"s3":{}}` | Configure to object storage |
+| objectStorage | object | `{"gcs":{},"oss":{},"s3":{}}` | Configure to object storage |
 | persistence.enableStatefulSetAutoDeletePVC | bool | `false` | Enable StatefulSetAutoDeletePVC feature |
 | persistence.enabled | bool | `true` | Enable persistent disk |
 | persistence.mountPath | string | `"/data/greptimedb"` | Mount path of persistent disk. |

--- a/charts/greptimedb-standalone/templates/_helpers.tpl
+++ b/charts/greptimedb-standalone/templates/_helpers.tpl
@@ -60,3 +60,25 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "greptimedb-standalone.objectStorageConfig" -}}
+{{- if or .Values.objectStorage.s3 .Values.objectStorage.oss .Values.objectStorage.gcs }}
+[storage]
+type = "{{- if .Values.objectStorage.s3 }}S3{{- else if .Values.objectStorage.oss }}Oss{{- else if .Values.objectStorage.gcs }}Gcs{{- end }}"
+
+bucket = "{{- if .Values.objectStorage.s3 }}{{ .Values.objectStorage.s3.bucket }}{{- else if .Values.objectStorage.oss }}{{ .Values.objectStorage.oss.bucket }}{{- else if .Values.objectStorage.gcs }}{{ .Values.objectStorage.gcs.bucket }}{{- end }}"
+
+root = "{{- if .Values.objectStorage.s3 }}{{ .Values.objectStorage.s3.root }}{{- else if .Values.objectStorage.oss }}{{ .Values.objectStorage.oss.root }}{{- else if .Values.objectStorage.gcs }}{{ .Values.objectStorage.gcs.root }}{{- end }}"
+
+{{- if .Values.objectStorage.s3 }}
+endpoint = "{{ .Values.objectStorage.s3.endpoint }}"
+region = "{{ .Values.objectStorage.s3.region }}"
+{{- else if .Values.objectStorage.oss }}
+endpoint = "{{ .Values.objectStorage.oss.endpoint }}"
+region = "{{ .Values.objectStorage.oss.region }}"
+{{- else if .Values.objectStorage.gcs }}
+endpoint = "{{ .Values.objectStorage.gcs.endpoint }}"
+scope = "{{ .Values.objectStorage.gcs.scope }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/greptimedb-standalone/templates/_helpers.tpl
+++ b/charts/greptimedb-standalone/templates/_helpers.tpl
@@ -90,9 +90,7 @@ Create the name of the service account to use
   bucket = "{{ $bucket }}"
 
   # Root path within the bucket
-  {{- if $root }}
   root = "{{ $root }}"
-  {{- end }}
 
 {{- if .Values.objectStorage.s3 }}
   endpoint = "{{ .Values.objectStorage.s3.endpoint }}"

--- a/charts/greptimedb-standalone/templates/_helpers.tpl
+++ b/charts/greptimedb-standalone/templates/_helpers.tpl
@@ -63,22 +63,47 @@ Create the name of the service account to use
 
 {{- define "greptimedb-standalone.objectStorageConfig" -}}
 {{- if or .Values.objectStorage.s3 .Values.objectStorage.oss .Values.objectStorage.gcs }}
-[storage]
-type = "{{- if .Values.objectStorage.s3 }}S3{{- else if .Values.objectStorage.oss }}Oss{{- else if .Values.objectStorage.gcs }}Gcs{{- end }}"
-
-bucket = "{{- if .Values.objectStorage.s3 }}{{ .Values.objectStorage.s3.bucket }}{{- else if .Values.objectStorage.oss }}{{ .Values.objectStorage.oss.bucket }}{{- else if .Values.objectStorage.gcs }}{{ .Values.objectStorage.gcs.bucket }}{{- end }}"
-
-root = "{{- if .Values.objectStorage.s3 }}{{ .Values.objectStorage.s3.root }}{{- else if .Values.objectStorage.oss }}{{ .Values.objectStorage.oss.root }}{{- else if .Values.objectStorage.gcs }}{{ .Values.objectStorage.gcs.root }}{{- end }}"
+{{- $provider := "" }}
+{{- $bucket := "" }}
+{{- $root := "" }}
 
 {{- if .Values.objectStorage.s3 }}
-endpoint = "{{ .Values.objectStorage.s3.endpoint }}"
-region = "{{ .Values.objectStorage.s3.region }}"
+  {{- $provider = "S3" }}
+  {{- $bucket = .Values.objectStorage.s3.bucket }}
+  {{- $root = .Values.objectStorage.s3.root }}
 {{- else if .Values.objectStorage.oss }}
-endpoint = "{{ .Values.objectStorage.oss.endpoint }}"
-region = "{{ .Values.objectStorage.oss.region }}"
+  {{- $provider = "Oss" }}
+  {{- $bucket = .Values.objectStorage.oss.bucket }}
+  {{- $root = .Values.objectStorage.oss.root }}
 {{- else if .Values.objectStorage.gcs }}
-endpoint = "{{ .Values.objectStorage.gcs.endpoint }}"
-scope = "{{ .Values.objectStorage.gcs.scope }}"
+  {{- $provider = "Gcs" }}
+  {{- $bucket = .Values.objectStorage.gcs.bucket }}
+  {{- $root = .Values.objectStorage.gcs.root }}
+{{- end }}
+
+{{- if and $provider $bucket }}
+[storage]
+  # Storage provider type: S3, Oss, or Gcs
+  type = "{{ $provider }}"
+
+  # Bucket name in the storage provider
+  bucket = "{{ $bucket }}"
+
+  # Root path within the bucket
+  {{- if $root }}
+  root = "{{ $root }}"
+  {{- end }}
+
+{{- if .Values.objectStorage.s3 }}
+  endpoint = "{{ .Values.objectStorage.s3.endpoint }}"
+  region = "{{ .Values.objectStorage.s3.region }}"
+{{- else if .Values.objectStorage.oss }}
+  endpoint = "{{ .Values.objectStorage.oss.endpoint }}"
+  region = "{{ .Values.objectStorage.oss.region }}"
+{{- else if .Values.objectStorage.gcs }}
+  endpoint = "{{ .Values.objectStorage.gcs.endpoint }}"
+  scope = "{{ .Values.objectStorage.gcs.scope }}"
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/greptimedb-standalone/templates/configmap.yaml
+++ b/charts/greptimedb-standalone/templates/configmap.yaml
@@ -9,4 +9,5 @@ metadata:
 data:
   config.toml: |
 {{ .Values.configToml | indent 4 }}
+{{ include "greptimedb-standalone.objectStorageConfig" . | indent 4 }}
 {{- end -}}

--- a/charts/greptimedb-standalone/templates/secret.yaml
+++ b/charts/greptimedb-standalone/templates/secret.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.objectStorage }}
 {{- if .Values.objectStorage.credentials }}
+{{- if not .Values.objectStorage.credentials.existingSecretName }}
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-secret
@@ -8,21 +9,14 @@ kind: Secret
 type: Opaque
 stringData:
   {{- if .Values.objectStorage.s3}}
-  GREPTIMEDB_STANDALONE__STORAGE__TYPE: "S3"
   GREPTIMEDB_STANDALONE__STORAGE__ACCESS_KEY_ID: {{ .Values.objectStorage.credentials.accessKeyId }}
   GREPTIMEDB_STANDALONE__STORAGE__SECRET_ACCESS_KEY: {{ .Values.objectStorage.credentials.secretAccessKey }}
-  GREPTIMEDB_STANDALONE__STORAGE__BUCKET: {{ .Values.objectStorage.s3.bucket}}
-  GREPTIMEDB_STANDALONE__STORAGE__ROOT: {{ .Values.objectStorage.s3.root }}
-  GREPTIMEDB_STANDALONE__STORAGE__REGION: {{ .Values.objectStorage.s3.region }}
-  GREPTIMEDB_STANDALONE__STORAGE__ENDPOINT: {{ .Values.objectStorage.s3.endpoint }}
   {{ else if .Values.objectStorage.oss }}
-  GREPTIMEDB_STANDALONE__STORAGE__TYPE: "Oss"
   GREPTIMEDB_STANDALONE__STORAGE__ACCESS_KEY_ID: {{ .Values.objectStorage.credentials.accessKeyId }}
   GREPTIMEDB_STANDALONE__STORAGE__ACCESS_KEY_SECRET: {{ .Values.objectStorage.credentials.secretAccessKey }}
-  GREPTIMEDB_STANDALONE__STORAGE__BUCKET: {{ .Values.objectStorage.oss.bucket}}
-  GREPTIMEDB_STANDALONE__STORAGE__ROOT: {{ .Values.objectStorage.oss.root }}
-  GREPTIMEDB_STANDALONE__STORAGE__REGION: {{ .Values.objectStorage.oss.region }}
-  GREPTIMEDB_STANDALONE__STORAGE__ENDPOINT: {{ .Values.objectStorage.oss.endpoint }}
+  {{ else if .Values.objectStorage.gcs }}
+  GREPTIMEDB_STANDALONE__STORAGE__CREDENTIAL: {{ .Values.objectStorage.credentials.serviceAccountKey }}
   {{- end}}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/greptimedb-standalone/templates/secret.yaml
+++ b/charts/greptimedb-standalone/templates/secret.yaml
@@ -7,16 +7,19 @@ metadata:
   namespace: {{ .Release.Namespace }}
 kind: Secret
 type: Opaque
+{{- if .Values.objectStorage.credentials.serviceAccountKey }}
+data:
+  GREPTIMEDB_STANDALONE__STORAGE__CREDENTIAL: {{ .Values.objectStorage.credentials.serviceAccountKey | b64enc }}
+{{- else }}
 stringData:
   {{- if .Values.objectStorage.s3}}
   GREPTIMEDB_STANDALONE__STORAGE__ACCESS_KEY_ID: {{ .Values.objectStorage.credentials.accessKeyId }}
   GREPTIMEDB_STANDALONE__STORAGE__SECRET_ACCESS_KEY: {{ .Values.objectStorage.credentials.secretAccessKey }}
   {{ else if .Values.objectStorage.oss }}
   GREPTIMEDB_STANDALONE__STORAGE__ACCESS_KEY_ID: {{ .Values.objectStorage.credentials.accessKeyId }}
-  GREPTIMEDB_STANDALONE__STORAGE__ACCESS_KEY_SECRET: {{ .Values.objectStorage.credentials.secretAccessKey }}
-  {{ else if .Values.objectStorage.gcs }}
-  GREPTIMEDB_STANDALONE__STORAGE__CREDENTIAL: {{ .Values.objectStorage.credentials.serviceAccountKey }}
-  {{- end}}
+  GREPTIMEDB_STANDALONE__STORAGE__ACCESS_KEY_SECRET: {{ .Values.objectStorage.credentials.accessKeySecret }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/greptimedb-standalone/templates/statefulset.yaml
+++ b/charts/greptimedb-standalone/templates/statefulset.yaml
@@ -97,7 +97,11 @@ spec:
           {{- if .Values.objectStorage.credentials }}
           envFrom:
             - secretRef:
+                {{- if .Values.objectStorage.credentials.existingSecretName }}
+                name: {{ .Values.objectStorage.credentials.existingSecretName }}
+                {{- else }}
                 name: {{ .Release.Name }}-secret
+                {{- end }}
           {{- end }}
           {{- end }}
           {{- with .Values.securityContext }}

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -42,8 +42,15 @@ dataHome: "/data/greptimedb/"
 # -- Configure to object storage
 objectStorage:
 #  credentials:
+#    # AWS or AliCloud cloudProvider accessKeyID and secretAccessKey
 #    accessKeyId: "you-should-set-the-access-key-id-here"
 #    secretAccessKey: "you-should-set-the-secret-access-key-here"
+
+#    # GCP cloudProvider serviceAccountKey JSON-formatted base64 value
+#    serviceAccountKey: "you-should-set-the-base64-service-account-key-here"
+
+#    # Set the existing secret to get the key's of cloudProvider
+#    existingSecretName: ""
 
   # configure to use s3 storage
   s3: {}
@@ -62,6 +69,15 @@ objectStorage:
   #  # The data directory in OSS will be: 'oss://<bucket>/<root>/data/...'.
   #  root: "greptimedb-standalone"
   #  endpoint: "oss-cn-hangzhou.aliyuncs.com"
+
+  # configure to use gcs storage
+  gcs: {}
+  #  bucket: "bucket-name"
+  #  scope: "" # example: "https://www.googleapis.com/auth/devstorage.read_write"
+
+  #  # The data directory in gcs will be: 'gcs://<bucket>/<root>/data/...'.
+  #  root: "mycluster"
+  #  endpoint: "https://storage.googleapis.com"
 
 # -- Environment variables
 env:

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -1,4 +1,3 @@
-
 image:
   # -- The image registry
   registry: docker.io

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -1,3 +1,4 @@
+
 image:
   # -- The image registry
   registry: docker.io
@@ -41,16 +42,21 @@ dataHome: "/data/greptimedb/"
 
 # -- Configure to object storage
 objectStorage:
-#  credentials:
-#    # AWS or AliCloud cloudProvider accessKeyID and secretAccessKey
-#    accessKeyId: "you-should-set-the-access-key-id-here"
-#    secretAccessKey: "you-should-set-the-secret-access-key-here"
+  #  credentials:
+  #    # AWS or AliCloud cloudProvider accessKeyID
+  #    accessKeyId: "you-should-set-the-access-key-id-here"
 
-#    # GCP cloudProvider serviceAccountKey JSON-formatted base64 value
-#    serviceAccountKey: "you-should-set-the-base64-service-account-key-here"
+  #    # AWS cloudProvider secretAccessKey
+  #    secretAccessKey: "you-should-set-the-secret-access-key-here"
 
-#    # Set the existing secret to get the key's of cloudProvider
-#    existingSecretName: ""
+  #    # AliCloud cloudProvider secretAccessKey
+  #    accessKeySecret: "you-should-set-the-access-key-secret-here"
+
+  #    # GCP cloudProvider serviceAccountKey JSON-formatted base64 value
+  #    serviceAccountKey: "you-should-set-the-base64-service-account-key-here"
+
+  #    # Set the existing secret to get the key's of cloudProvider
+  #    existingSecretName: ""
 
   # configure to use s3 storage
   s3: {}
@@ -76,7 +82,7 @@ objectStorage:
   #  scope: "" # example: "https://www.googleapis.com/auth/devstorage.read_write"
 
   #  # The data directory in gcs will be: 'gcs://<bucket>/<root>/data/...'.
-  #  root: "mycluster"
+  #  root: "greptimedb-standalone"
   #  endpoint: "https://storage.googleapis.com"
 
 # -- Environment variables


### PR DESCRIPTION
Keep the keyID、secretkey information of the object storage secret, move other configurations to `_helpers.tpl` file, and configure it to GreptimeDB in the form of a toml file.
Add google cloud storage configurations.
Wait me to test...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated Helm charts for both `greptimedb-cluster` and `greptimedb-standalone` to version `0.2.23` and `0.1.25`, respectively.
	- Introduced support for Google Cloud Storage (GCS) in the object storage configurations for both clusters.
	- Added new configuration options for debugging, monitoring, and logging in `greptimedb-cluster`.
	- Enhanced object storage configuration options in `greptimedb-standalone`, including new placeholders for GCS settings.

- **Bug Fixes**
	- Enhanced secret management for object storage credentials in `greptimedb-standalone`.

- **Documentation**
	- Updated README files to reflect new version numbers and configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->