### PR TITLE
chore(greptimedb-standalone): setting persistentVolumeClaimRetentionPolicy default is retain

### DIFF
--- a/charts/greptimedb-standalone/Chart.yaml
+++ b/charts/greptimedb-standalone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-standalone
 description: A Helm chart for deploying standalone greptimedb
 type: application
-version: 0.1.25
+version: 0.1.26
 appVersion: 0.9.5
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying standalone greptimedb
 
-![Version: 0.1.25](https://img.shields.io/badge/Version-0.1.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
+![Version: 0.1.26](https://img.shields.io/badge/Version-0.1.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
 
 ## Source Code
 - https://github.com/GreptimeTeam/greptimedb
@@ -79,6 +79,7 @@ helm uninstall greptimedb-standalone -n default
 | persistence.selector | string | `nil` | Selector for persistent disk |
 | persistence.size | string | `"10Gi"` | Size of persistent disk |
 | persistence.storageClass | string | `nil` | Storage class name |
+| persistentVolumeClaimRetentionPolicy | object | `{"whenDeleted":"Retain","whenScaled":"Retain"}` | PersistentVolumeClaimRetentionPolicyType is a string enumeration of the policies that will determine, when volumes from the VolumeClaimTemplates will be deleted when the controlling StatefulSet is deleted or scaled down. |
 | podAnnotations | object | `{}` | Extra pod annotations to add |
 | podLabels | object | `{}` | Extra pod labels to add |
 | podSecurityContext | object | `{}` | Security context to apply to the pod |

--- a/charts/greptimedb-standalone/templates/statefulset.yaml
+++ b/charts/greptimedb-standalone/templates/statefulset.yaml
@@ -19,8 +19,8 @@ spec:
   serviceName: {{ include "greptimedb-standalone.fullname" . }}
   {{- if and (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) (.Values.persistence.enableStatefulSetAutoDeletePVC) (.Values.persistence.enabled) }}
   persistentVolumeClaimRetentionPolicy:
-    whenDeleted: Delete
-    whenScaled: Delete
+    whenDeleted: {{ .Values.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -157,6 +157,11 @@ affinity: {}
 # -- Grace period to allow the single binary to shut down before it is killed
 terminationGracePeriodSeconds: 30
 
+# -- PersistentVolumeClaimRetentionPolicyType is a string enumeration of the policies that will determine, when volumes from the VolumeClaimTemplates will be deleted when the controlling StatefulSet is deleted or scaled down.
+persistentVolumeClaimRetentionPolicy:
+  whenDeleted: Retain
+  whenScaled: Retain
+
 persistence:
   # -- Enable persistent disk
   enabled: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `persistentVolumeClaimRetentionPolicy` setting, allowing users to control retention of persistent volume claims when the StatefulSet is deleted or scaled down.
  
- **Updates**
	- Version number updated from `0.1.25` to `0.1.26` in the Helm chart and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->