### PR TITLE
fix(greptimedb-cluster): e2e failed and release cluster chart to ACR failed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      release-charts-to-acr:
+        description: Release the Helm charts to ACR
+        required: false
+        default: 'false'
 
 jobs:
   release:
@@ -39,6 +44,7 @@ jobs:
 
   release-charts-to-acr:
     runs-on: ubuntu-latest
+    if: ${{ inputs.release-charts-to-acr == 'true' || github.event_name == 'push' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/scripts/e2e/greptimedb-cluster.sh
+++ b/scripts/e2e/greptimedb-cluster.sh
@@ -52,7 +52,12 @@ function drop_table() {
 }
 
 function deploy_greptimedb_cluster() {
-  helm upgrade --install mycluster greptimedb-cluster -n default
+  # Handle greptimedb-cluster dependencies.
+  helm repo add grafana https://grafana.github.io/helm-charts
+  helm dependency build charts/greptimedb-cluster
+
+  # Deploy greptimedb cluster.
+  helm upgrade --install mycluster charts/greptimedb-cluster -n default
 
   timeout=300
   sleep_interval=5
@@ -76,8 +81,7 @@ function deploy_greptimedb_cluster() {
 }
 
 function deploy_greptimedb_operator() {
-  cd charts
-  helm upgrade --install greptimedb-operator greptimedb-operator -n default
+  helm upgrade --install greptimedb-operator charts/greptimedb-operator -n default
 
   # Wait for greptimedb operator to be ready
   kubectl rollout status --timeout=60s deployment/greptimedb-operator -n default

--- a/scripts/release/release-charts-to-acr.sh
+++ b/scripts/release/release-charts-to-acr.sh
@@ -22,7 +22,7 @@ for dir in "$CHARTS_DIR"/*; do
     helm package "$dir" --destination "$dir"
 
     # Get the packaged chart file path.
-    packaged_file=$(find "$dir" -type f -name "*.tgz" ! -name "grafana-*.tgz")
+    packaged_file=$(find "$dir" -type f -name "${chart_name}-*.tgz" -print -quit)
 
     echo "Package $chart_name to $packaged_file and push to oci://$OCI_REGISTRY_URL/$OCI_NAMESPACE/$chart_name ..."
 

--- a/scripts/release/release-charts-to-acr.sh
+++ b/scripts/release/release-charts-to-acr.sh
@@ -4,7 +4,7 @@ OCI_REGISTRY_URL=${OCI_REGISTRY_URL:-"greptime-registry.cn-hangzhou.cr.aliyuncs.
 OCI_NAMESPACE=${OCI_NAMESPACE:-"charts"}
 CHARTS_DIR="charts"
 
-for dir in "$CHARTS_DIR"/*/; do
+for dir in "$CHARTS_DIR"/*; do
   # Ensure the directory exists and is not empty.
   if [ -d "$dir" ]; then
     # Get the chart name from the directory path.
@@ -22,7 +22,7 @@ for dir in "$CHARTS_DIR"/*/; do
     helm package "$dir" --destination "$dir"
 
     # Get the packaged chart file path.
-    packaged_file=$(find "$dir" -type f -name "*.tgz")
+    packaged_file=$(find "$dir" -type f -name "*.tgz" ! -name "grafana-*.tgz")
 
     echo "Package $chart_name to $packaged_file and push to oci://$OCI_REGISTRY_URL/$OCI_NAMESPACE/$chart_name ..."
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional input parameter for the GitHub Actions workflow to control the release of Helm charts to Azure Container Registry (ACR).
	- Enhanced deployment scripts to manage dependencies and specify chart paths for the greptimedb cluster and operator.
- **Bug Fixes**
	- Improved handling of directories in the chart release script to ensure only relevant packaged charts are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->