### PR TITLE
feat(greptimedb-standalone): add extra volume mount

### DIFF
--- a/charts/greptimedb-standalone/Chart.yaml
+++ b/charts/greptimedb-standalone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-standalone
 description: A Helm chart for deploying standalone greptimedb
 type: application
-version: 0.1.27
+version: 0.1.28
 appVersion: 0.9.5
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying standalone greptimedb
 
-![Version: 0.1.27](https://img.shields.io/badge/Version-0.1.27-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
+![Version: 0.1.28](https://img.shields.io/badge/Version-0.1.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
 
 ## Source Code
 - https://github.com/GreptimeTeam/greptimedb
@@ -57,6 +57,8 @@ helm uninstall greptimedb-standalone -n default
 | configToml | string | `"mode = 'standalone'\n"` | The extra configuration for greptimedb |
 | dataHome | string | `"/data/greptimedb/"` | Storage root directory |
 | env | object | `{"GREPTIMEDB_STANDALONE__HTTP__ADDR":"0.0.0.0:4000"}` | Environment variables |
+| extraVolumeMounts | list | `[]` | Volume mounts to add to the pods |
+| extraVolumes | list | `[]` | Volumes to add to the pods |
 | fullnameOverride | string | `""` | Provide a name to substitute for the full names of resources |
 | grpcServicePort | int | `4001` | GreptimeDB grpc service port |
 | httpServicePort | int | `4000` | GreptimeDB http service port |

--- a/charts/greptimedb-standalone/templates/statefulset.yaml
+++ b/charts/greptimedb-standalone/templates/statefulset.yaml
@@ -116,15 +116,23 @@ spec:
               mountPath: /etc/greptimedb
               readOnly: true
             {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+                {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if .Values.configToml }}
+      {{- if or .Values.configToml .Values.extraVolumes }}
       volumes:
+        {{- if .Values.configToml }}
         - name: config
           configMap:
             name: {{ .Release.Name }}-config
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -127,6 +127,11 @@ resources: {}
 nodeSelector: {}
 #  disktype: ssd
 
+# -- Volume mounts to add to the pods
+extraVolumeMounts: []
+# -- Volumes to add to the pods
+extraVolumes: []
+
 # -- Tolerations to apply pod
 tolerations: {}
 #  - key: "key1"


### PR DESCRIPTION
I want to mount tls certificate into the pod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version of the `greptimedb-standalone` Helm chart to 0.1.28.
	- Added configuration options for `extraVolumeMounts` and `extraVolumes` to enhance deployment flexibility.

- **Documentation**
	- Updated README to reflect new configuration options and version change.

- **Bug Fixes**
	- Improved handling of volume mounts and volumes in the StatefulSet configuration for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->