### PR TITLE
feat(greptimedb-standalone): add objectstorage `cache_path` configuration

### DIFF
--- a/charts/greptimedb-standalone/Chart.yaml
+++ b/charts/greptimedb-standalone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-standalone
 description: A Helm chart for deploying standalone greptimedb
 type: application
-version: 0.1.28
+version: 0.1.29
 appVersion: 0.9.5
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying standalone greptimedb
 
-![Version: 0.1.28](https://img.shields.io/badge/Version-0.1.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
+![Version: 0.1.29](https://img.shields.io/badge/Version-0.1.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
 
 ## Source Code
 - https://github.com/GreptimeTeam/greptimedb

--- a/charts/greptimedb-standalone/templates/_helpers.tpl
+++ b/charts/greptimedb-standalone/templates/_helpers.tpl
@@ -66,19 +66,23 @@ Create the name of the service account to use
 {{- $provider := "" }}
 {{- $bucket := "" }}
 {{- $root := "" }}
+{{- $cache_path := "" }}
 
 {{- if .Values.objectStorage.s3 }}
   {{- $provider = "S3" }}
   {{- $bucket = .Values.objectStorage.s3.bucket }}
   {{- $root = .Values.objectStorage.s3.root }}
+  {{- $cache_path = .Values.objectStorage.s3.cache_path }}
 {{- else if .Values.objectStorage.oss }}
   {{- $provider = "Oss" }}
   {{- $bucket = .Values.objectStorage.oss.bucket }}
   {{- $root = .Values.objectStorage.oss.root }}
+  {{- $cache_path = .Values.objectStorage.oss.cache_path }}
 {{- else if .Values.objectStorage.gcs }}
   {{- $provider = "Gcs" }}
   {{- $bucket = .Values.objectStorage.gcs.bucket }}
   {{- $root = .Values.objectStorage.gcs.root }}
+  {{- $cache_path = .Values.objectStorage.gcs.cache_path }}
 {{- end }}
 
 {{- if and $provider $bucket }}
@@ -91,6 +95,9 @@ Create the name of the service account to use
 
   # Root path within the bucket
   root = "{{ $root }}"
+
+  # Cache path configuration
+  cache_path = "{{ $cache_path }}"
 
 {{- if .Values.objectStorage.s3 }}
   endpoint = "{{ .Values.objectStorage.s3.endpoint }}"

--- a/charts/greptimedb-standalone/templates/_helpers.tpl
+++ b/charts/greptimedb-standalone/templates/_helpers.tpl
@@ -97,7 +97,9 @@ Create the name of the service account to use
   root = "{{ $root }}"
 
   # Cache path configuration
+  {{- if $cache_path }}
   cache_path = "{{ $cache_path }}"
+  {{- end }}
 
 {{- if .Values.objectStorage.s3 }}
   endpoint = "{{ .Values.objectStorage.s3.endpoint }}"

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -66,6 +66,9 @@ objectStorage:
   #  root: "greptimedb-standalone"
   #  endpoint: ""  # See more detail: https://docs.aws.amazon.com/general/latest/gr/s3.html
 
+  #  # Cache path configuration for object storage
+  #  cache_path: ""
+
   # configure to use oss storage
   oss: {}
   #  bucket: "bucket-name"
@@ -75,6 +78,9 @@ objectStorage:
   #  root: "greptimedb-standalone"
   #  endpoint: "oss-cn-hangzhou.aliyuncs.com"
 
+  #  # Cache path configuration
+  #  cache_path: ""
+
   # configure to use gcs storage
   gcs: {}
   #  bucket: "bucket-name"
@@ -83,6 +89,9 @@ objectStorage:
   #  # The data directory in gcs will be: 'gcs://<bucket>/<root>/data/...'.
   #  root: "greptimedb-standalone"
   #  endpoint: "https://storage.googleapis.com"
+
+  #  # Cache path for object storage
+  #  cache_path: ""
 
 # -- Environment variables
 env:

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -66,7 +66,7 @@ objectStorage:
   #  root: "greptimedb-standalone"
   #  endpoint: ""  # See more detail: https://docs.aws.amazon.com/general/latest/gr/s3.html
 
-  #  # Cache path configuration for object storage
+  #  # Cache path configuration
   #  cache_path: ""
 
   # configure to use oss storage
@@ -90,7 +90,7 @@ objectStorage:
   #  root: "greptimedb-standalone"
   #  endpoint: "https://storage.googleapis.com"
 
-  #  # Cache path for object storage
+  #  # Cache path configuration
   #  cache_path: ""
 
 # -- Environment variables


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version of the `greptimedb-standalone` Helm chart to `0.1.29`.
	- Introduced a new variable for cache path configuration in object storage settings.
- **Documentation**
	- Updated README to reflect the new chart version.
	- Added comments in `values.yaml` for cache path configuration options for S3, OSS, and GCS storage types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->