### PR TITLE
refactor(greptimedb-standalone): rename secret and configmap

### DIFF
--- a/charts/greptimedb-standalone/Chart.yaml
+++ b/charts/greptimedb-standalone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-standalone
 description: A Helm chart for deploying standalone greptimedb
 type: application
-version: 0.1.30
+version: 0.1.31
 appVersion: 0.9.5
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying standalone greptimedb
 
-![Version: 0.1.30](https://img.shields.io/badge/Version-0.1.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
+![Version: 0.1.31](https://img.shields.io/badge/Version-0.1.31-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
 
 ## Source Code
 - https://github.com/GreptimeTeam/greptimedb

--- a/charts/greptimedb-standalone/templates/configmap.yaml
+++ b/charts/greptimedb-standalone/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-config
+  name: {{ include "greptimedb-standalone.fullname" . }}-config
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "greptimedb-standalone.labels" . | nindent 4 }}

--- a/charts/greptimedb-standalone/templates/secret.yaml
+++ b/charts/greptimedb-standalone/templates/secret.yaml
@@ -3,7 +3,7 @@
 {{- if not .Values.objectStorage.credentials.existingSecretName }}
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-secret
+  name: {{ include "greptimedb-standalone.fullname" . }}-secret
   namespace: {{ .Release.Namespace }}
 kind: Secret
 type: Opaque

--- a/charts/greptimedb-standalone/templates/serviceaccount.yaml
+++ b/charts/greptimedb-standalone/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/greptimedb-standalone/templates/statefulset.yaml
+++ b/charts/greptimedb-standalone/templates/statefulset.yaml
@@ -100,7 +100,7 @@ spec:
                 {{- if .Values.objectStorage.credentials.existingSecretName }}
                 name: {{ .Values.objectStorage.credentials.existingSecretName }}
                 {{- else }}
-                name: {{ .Release.Name }}-secret
+                name: {{ include "greptimedb-standalone.fullname" . }}-secret
                 {{- end }}
           {{- end }}
           {{- end }}
@@ -128,7 +128,7 @@ spec:
         {{- if .Values.configToml }}
         - name: config
           configMap:
-            name: {{ .Release.Name }}-config
+            name: {{ include "greptimedb-standalone.fullname" . }}-config
         {{- end }}
         {{- with .Values.extraVolumes }}
             {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
When `.Release.Name` name is **internal**, the names of configmap and secret are `internal-config` and `internal-secret`. After modification, the names is `internal-greptimedb-standalone-config` and `internal-greptimedb-standalone-secret`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version of the `greptimedb-standalone` Helm chart to version `0.1.31`.
	- Enhanced naming conventions for Kubernetes secrets and config maps to improve clarity and consistency.
  
- **Bug Fixes**
	- Corrected control flow in the ServiceAccount template to ensure proper execution of conditional statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->