### PR TITLE
refactor: add startup probe

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.2.27
+version: 0.2.28
 appVersion: 0.9.5
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.2.27](https://img.shields.io/badge/Version-0.2.27-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
+![Version: 0.2.28](https://img.shields.io/badge/Version-0.2.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
 
 ## Source Code
 
@@ -84,11 +84,11 @@ helm uninstall mycluster -n default
 | auth.fileName | string | `"passwd"` | The auth file name, the full path is `${mountPath}/${fileName}` |
 | auth.mountPath | string | `"/etc/greptimedb/auth"` | The auth file path to store the auth info |
 | auth.users | list | `[{"password":"admin","username":"admin"}]` | The users to be created in the auth file |
-| base.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}}},"nodeSelector":{},"serviceAccountName":"","tolerations":[]}` | The pod template for base |
+| base.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"startupProbe":{}},"nodeSelector":{},"serviceAccountName":"","tolerations":[]}` | The pod template for base |
 | base.podTemplate.affinity | object | `{}` | The pod affinity |
 | base.podTemplate.annotations | object | `{}` | The annotations to be created to the pod. |
 | base.podTemplate.labels | object | `{}` | The labels to be created to the pod. |
-| base.podTemplate.main | object | `{"args":[],"command":[],"env":[],"livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}}}` | The base spec of main container |
+| base.podTemplate.main | object | `{"args":[],"command":[],"env":[],"livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"startupProbe":{}}` | The base spec of main container |
 | base.podTemplate.main.args | list | `[]` | The arguments to be passed to the command |
 | base.podTemplate.main.command | list | `[]` | The command to be executed in the container |
 | base.podTemplate.main.env | list | `[]` | The environment variables for the container |
@@ -96,18 +96,19 @@ helm uninstall mycluster -n default
 | base.podTemplate.main.readinessProbe | object | `{}` | The config for readiness probe of the main container |
 | base.podTemplate.main.resources.limits | object | `{}` | The resources limits for the container |
 | base.podTemplate.main.resources.requests | object | `{}` | The requested resources for the container |
+| base.podTemplate.main.startupProbe | object | `{}` | The config for startup probe of the main container |
 | base.podTemplate.nodeSelector | object | `{}` | The pod node selector |
 | base.podTemplate.serviceAccountName | string | `""` | The global service account |
 | base.podTemplate.tolerations | list | `[]` | The pod tolerations |
-| datanode | object | `{"configData":"","configFile":"","logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"storage":{"dataHome":"/data/greptimedb","mountPath":"/data/greptimedb","storageClassName":null,"storageRetainPolicy":"Retain","storageSize":"10Gi","walDir":"/data/greptimedb/wal"}}` | Datanode configure |
+| datanode | object | `{"configData":"","configFile":"","logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"storage":{"dataHome":"/data/greptimedb","mountPath":"/data/greptimedb","storageClassName":null,"storageRetainPolicy":"Retain","storageSize":"10Gi","walDir":"/data/greptimedb/wal"}}` | Datanode configure |
 | datanode.configData | string | `""` | Extra raw toml config data of datanode. Skip if the `configFile` is used. |
 | datanode.configFile | string | `""` | Extra toml file of datanode. |
 | datanode.logging | object | `{}` | Logging configuration for datanode, if not set, it will use the global logging configuration. |
-| datanode.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for datanode |
+| datanode.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for datanode |
 | datanode.podTemplate.affinity | object | `{}` | The pod affinity |
 | datanode.podTemplate.annotations | object | `{}` | The annotations to be created to the pod. |
 | datanode.podTemplate.labels | object | `{}` | The labels to be created to the pod. |
-| datanode.podTemplate.main | object | `{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]}` | The spec of main container |
+| datanode.podTemplate.main | object | `{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"startupProbe":{},"volumeMounts":[]}` | The spec of main container |
 | datanode.podTemplate.main.args | list | `[]` | The arguments to be passed to the command |
 | datanode.podTemplate.main.command | list | `[]` | The command to be executed in the container |
 | datanode.podTemplate.main.env | list | `[]` | The environment variables for the container |
@@ -116,6 +117,7 @@ helm uninstall mycluster -n default
 | datanode.podTemplate.main.readinessProbe | object | `{}` | The config for readiness probe of the main container |
 | datanode.podTemplate.main.resources.limits | object | `{}` | The resources limits for the container |
 | datanode.podTemplate.main.resources.requests | object | `{}` | The requested resources for the container |
+| datanode.podTemplate.main.startupProbe | object | `{}` | The config for startup probe of the main container |
 | datanode.podTemplate.main.volumeMounts | list | `[]` | The pod volumeMounts |
 | datanode.podTemplate.nodeSelector | object | `{}` | The pod node selector |
 | datanode.podTemplate.serviceAccount.annotations | object | `{}` | The annotations for datanode serviceaccount |
@@ -132,16 +134,16 @@ helm uninstall mycluster -n default
 | debugPod.enabled | bool | `false` | Enable debug pod |
 | debugPod.image | object | `{"registry":"docker.io","repository":"greptime/greptime-tool","tag":"20240905-67eaa147"}` | The debug pod image |
 | debugPod.resources | object | `{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | The debug pod resource |
-| flownode | object | `{"configData":"","configFile":"","enabled":false,"logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1}` | Flownode configure. **It's NOT READY YET** |
+| flownode | object | `{"configData":"","configFile":"","enabled":false,"logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1}` | Flownode configure. **It's NOT READY YET** |
 | flownode.configData | string | `""` | Extra raw toml config data of flownode. Skip if the `configFile` is used. |
 | flownode.configFile | string | `""` | Extra toml file of flownode. |
 | flownode.enabled | bool | `false` | Enable flownode |
 | flownode.logging | object | `{}` | Logging configuration for flownode, if not set, it will use the global logging configuration. |
-| flownode.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for frontend |
+| flownode.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for frontend |
 | flownode.podTemplate.affinity | object | `{}` | The pod affinity |
 | flownode.podTemplate.annotations | object | `{}` | The annotations to be created to the pod. |
 | flownode.podTemplate.labels | object | `{}` | The labels to be created to the pod. |
-| flownode.podTemplate.main | object | `{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]}` | The spec of main container |
+| flownode.podTemplate.main | object | `{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"startupProbe":{},"volumeMounts":[]}` | The spec of main container |
 | flownode.podTemplate.main.args | list | `[]` | The arguments to be passed to the command |
 | flownode.podTemplate.main.command | list | `[]` | The command to be executed in the container |
 | flownode.podTemplate.main.env | list | `[]` | The environment variables for the container |
@@ -150,6 +152,7 @@ helm uninstall mycluster -n default
 | flownode.podTemplate.main.readinessProbe | object | `{}` | The config for readiness probe of the main container |
 | flownode.podTemplate.main.resources.limits | object | `{}` | The resources limits for the container |
 | flownode.podTemplate.main.resources.requests | object | `{}` | The requested resources for the container |
+| flownode.podTemplate.main.startupProbe | object | `{}` | The config for startup probe of the main container |
 | flownode.podTemplate.main.volumeMounts | list | `[]` | The pod volumeMounts |
 | flownode.podTemplate.nodeSelector | object | `{}` | The pod node selector |
 | flownode.podTemplate.serviceAccount.annotations | object | `{}` | The annotations for flownode serviceaccount |
@@ -157,15 +160,15 @@ helm uninstall mycluster -n default
 | flownode.podTemplate.tolerations | list | `[]` | The pod tolerations |
 | flownode.podTemplate.volumes | list | `[]` | The pod volumes |
 | flownode.replicas | int | `1` | Flownode replicas |
-| frontend | object | `{"configData":"","configFile":"","logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"service":{},"tls":{}}` | Frontend configure |
+| frontend | object | `{"configData":"","configFile":"","logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"service":{},"tls":{}}` | Frontend configure |
 | frontend.configData | string | `""` | Extra raw toml config data of frontend. Skip if the `configFile` is used. |
 | frontend.configFile | string | `""` | Extra toml file of frontend. |
 | frontend.logging | object | `{}` | Logging configuration for frontend, if not set, it will use the global logging configuration. |
-| frontend.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for frontend |
+| frontend.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for frontend |
 | frontend.podTemplate.affinity | object | `{}` | The pod affinity |
 | frontend.podTemplate.annotations | object | `{}` | The annotations to be created to the pod. |
 | frontend.podTemplate.labels | object | `{}` | The labels to be created to the pod. |
-| frontend.podTemplate.main | object | `{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]}` | The spec of main container |
+| frontend.podTemplate.main | object | `{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"startupProbe":{},"volumeMounts":[]}` | The spec of main container |
 | frontend.podTemplate.main.args | list | `[]` | The arguments to be passed to the command |
 | frontend.podTemplate.main.command | list | `[]` | The command to be executed in the container |
 | frontend.podTemplate.main.env | list | `[]` | The environment variables for the container |
@@ -174,6 +177,7 @@ helm uninstall mycluster -n default
 | frontend.podTemplate.main.readinessProbe | object | `{}` | The config for readiness probe of the main container |
 | frontend.podTemplate.main.resources.limits | object | `{}` | The resources limits for the container |
 | frontend.podTemplate.main.resources.requests | object | `{}` | The requested resources for the container |
+| frontend.podTemplate.main.startupProbe | object | `{}` | The config for startup probe of the main container |
 | frontend.podTemplate.main.volumeMounts | list | `[]` | The pod volumeMounts |
 | frontend.podTemplate.nodeSelector | object | `{}` | The pod node selector |
 | frontend.podTemplate.serviceAccount.annotations | object | `{}` | The annotations for frontend serviceaccount |
@@ -224,17 +228,17 @@ helm uninstall mycluster -n default
 | logging.slowQuery.enabled | bool | `false` | Enable slow query log. |
 | logging.slowQuery.sampleRatio | string | `"1.0"` | Sample ratio of slow query log. |
 | logging.slowQuery.threshold | string | `"10s"` | The threshold of slow query log in seconds. |
-| meta | object | `{"configData":"","configFile":"","enableRegionFailover":false,"etcdEndpoints":"etcd.etcd-cluster.svc.cluster.local:2379","logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"storeKeyPrefix":""}` | Meta configure |
+| meta | object | `{"configData":"","configFile":"","enableRegionFailover":false,"etcdEndpoints":"etcd.etcd-cluster.svc.cluster.local:2379","logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"storeKeyPrefix":""}` | Meta configure |
 | meta.configData | string | `""` | Extra raw toml config data of meta. Skip if the `configFile` is used. |
 | meta.configFile | string | `""` | Extra toml file of meta. |
 | meta.enableRegionFailover | bool | `false` | Whether to enable region failover |
 | meta.etcdEndpoints | string | `"etcd.etcd-cluster.svc.cluster.local:2379"` | Meta etcd endpoints |
 | meta.logging | object | `{}` | Logging configuration for meta, if not set, it will use the global logging configuration. |
-| meta.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for meta |
+| meta.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for meta |
 | meta.podTemplate.affinity | object | `{}` | The pod affinity |
 | meta.podTemplate.annotations | object | `{}` | The annotations to be created to the pod. |
 | meta.podTemplate.labels | object | `{}` | The labels to be created to the pod. |
-| meta.podTemplate.main | object | `{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"volumeMounts":[]}` | The spec of main container |
+| meta.podTemplate.main | object | `{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"startupProbe":{},"volumeMounts":[]}` | The spec of main container |
 | meta.podTemplate.main.args | list | `[]` | The arguments to be passed to the command |
 | meta.podTemplate.main.command | list | `[]` | The command to be executed in the container |
 | meta.podTemplate.main.env | list | `[]` | The environment variables for the container |
@@ -243,6 +247,7 @@ helm uninstall mycluster -n default
 | meta.podTemplate.main.readinessProbe | object | `{}` | The config for readiness probe of the main container |
 | meta.podTemplate.main.resources.limits | object | `{}` | The resources limits for the container |
 | meta.podTemplate.main.resources.requests | object | `{}` | The requested resources for the container |
+| meta.podTemplate.main.startupProbe | object | `{}` | The config for startup probe of the main container |
 | meta.podTemplate.main.volumeMounts | list | `[]` | The pod volumeMounts |
 | meta.podTemplate.nodeSelector | object | `{}` | The pod node selector |
 | meta.podTemplate.serviceAccount.annotations | object | `{}` | The annotations for meta serviceaccount |

--- a/charts/greptimedb-cluster/templates/cluster.yaml
+++ b/charts/greptimedb-cluster/templates/cluster.yaml
@@ -19,6 +19,9 @@ spec:
       {{- if .Values.base.podTemplate.main.env }}
       env: {{- toYaml .Values.base.podTemplate.main.env | nindent 8 }}
       {{- end }}
+      {{- if .Values.base.podTemplate.main.startupProbe }}
+      startupProbe: {{- toYaml .Values.base.podTemplate.main.startupProbe | nindent 8 }}
+      {{- end }}
       {{- if .Values.base.podTemplate.main.readinessProbe }}
       readinessProbe: {{- toYaml .Values.base.podTemplate.main.readinessProbe | nindent 8 }}
       {{- end }}
@@ -100,6 +103,9 @@ spec:
         resources:
           requests: {{ .Values.frontend.podTemplate.main.resources.requests | toYaml | nindent 12 }}
           limits: {{ .Values.frontend.podTemplate.main.resources.limits | toYaml | nindent 12 }}
+        {{- if .Values.frontend.podTemplate.main.startupProbe }}
+        startupProbe: {{- toYaml .Values.frontend.podTemplate.main.startupProbe | nindent 10 }}
+        {{- end }}
         {{- if .Values.frontend.podTemplate.main.readinessProbe }}
         readinessProbe: {{- toYaml .Values.frontend.podTemplate.main.readinessProbe | nindent 10 }}
         {{- end }}
@@ -217,6 +223,9 @@ spec:
         resources:
           requests: {{ .Values.meta.podTemplate.main.resources.requests | toYaml | nindent 12 }}
           limits: {{ .Values.meta.podTemplate.main.resources.limits | toYaml | nindent 12 }}
+        {{- if .Values.meta.podTemplate.main.startupProbe }}
+        startupProbe: {{- toYaml .Values.meta.podTemplate.main.startupProbe | nindent 10 }}
+        {{- end }}
         {{- if .Values.meta.podTemplate.main.readinessProbe }}
         readinessProbe: {{- toYaml .Values.meta.podTemplate.main.readinessProbe | nindent 10 }}
         {{- end }}
@@ -274,6 +283,9 @@ spec:
         resources:
           requests: {{ .Values.datanode.podTemplate.main.resources.requests | toYaml | nindent 12 }}
           limits: {{ .Values.datanode.podTemplate.main.resources.limits | toYaml | nindent 12 }}
+        {{- if .Values.datanode.podTemplate.main.startupProbe }}
+        startupProbe: {{- toYaml .Values.datanode.podTemplate.main.startupProbe | nindent 10 }}
+        {{- end }}
         {{- if .Values.datanode.podTemplate.main.readinessProbe }}
         readinessProbe: {{- toYaml .Values.datanode.podTemplate.main.readinessProbe | nindent 10 }}
         {{- end }}
@@ -360,6 +372,9 @@ spec:
         resources:
           requests: {{ .Values.flownode.podTemplate.main.resources.requests | toYaml | nindent 12 }}
           limits: {{ .Values.flownode.podTemplate.main.resources.limits | toYaml | nindent 12 }}
+        {{- if .Values.flownode.podTemplate.main.startupProbe }}
+        startupProbe: {{- toYaml .Values.flownode.podTemplate.main.startupProbe | nindent 10 }}
+        {{- end }}
         {{- if .Values.flownode.podTemplate.main.readinessProbe }}
         readinessProbe: {{- toYaml .Values.flownode.podTemplate.main.readinessProbe | nindent 10 }}
         {{- end }}

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -41,6 +41,24 @@ base:
       # -- The arguments to be passed to the command
       args: []
 
+      # -- The config for startup probe of the main container
+      startupProbe: {}
+#        httpGet:
+#          # -- Path to access on the HTTP server
+#          path: /health
+#          # -- Name or number of the port to access on the container
+#          port: 4000
+#          # -- The initial delay seconds for the readiness probe.
+#          initialDelaySeconds: 5
+#          # -- The timeout seconds for the readiness probe
+#          timeoutSeconds: 1
+#          # -- The period seconds for the readiness probe
+#          periodSeconds: 10
+#          # -- The success threshold for the readiness probe
+#          successThreshold: 1
+#          # -- The failure threshold for the readiness probe
+#          failureThreshold: 3
+
       # -- The config for readiness probe of the main container
       readinessProbe: {}
 #        httpGet:
@@ -130,6 +148,24 @@ frontend:
 
       # -- The pod volumeMounts
       volumeMounts: []
+
+      # -- The config for startup probe of the main container
+      startupProbe: {}
+#        httpGet:
+#          # -- Path to access on the HTTP server
+#          path: /health
+#          # -- Name or number of the port to access on the container
+#          port: 4000
+#          # -- The initial delay seconds for the readiness probe.
+#          initialDelaySeconds: 5
+#          # -- The timeout seconds for the readiness probe
+#          timeoutSeconds: 1
+#          # -- The period seconds for the readiness probe
+#          periodSeconds: 10
+#          # -- The success threshold for the readiness probe
+#          successThreshold: 1
+#          # -- The failure threshold for the readiness probe
+#          failureThreshold: 3
 
       # -- The config for readiness probe of the main container
       readinessProbe: {}
@@ -253,6 +289,24 @@ meta:
 
       # -- The pod volumeMounts
       volumeMounts: []
+
+      # -- The config for startup probe of the main container
+      startupProbe: {}
+#        httpGet:
+#          # -- Path to access on the HTTP server
+#          path: /health
+#          # -- Name or number of the port to access on the container
+#          port: 4000
+#          # -- The initial delay seconds for the readiness probe.
+#          initialDelaySeconds: 5
+#          # -- The timeout seconds for the readiness probe
+#          timeoutSeconds: 1
+#          # -- The period seconds for the readiness probe
+#          periodSeconds: 10
+#          # -- The success threshold for the readiness probe
+#          successThreshold: 1
+#          # -- The failure threshold for the readiness probe
+#          failureThreshold: 3
 
       # -- The config for readiness probe of the main container
       readinessProbe: {}
@@ -378,6 +432,23 @@ datanode:
 
       # -- The pod volumeMounts
       volumeMounts: []
+      # -- The config for startup probe of the main container
+      startupProbe: {}
+#        httpGet:
+#          # -- Path to access on the HTTP server
+#          path: /health
+#          # -- Name or number of the port to access on the container
+#          port: 4000
+#          # -- The initial delay seconds for the readiness probe.
+#          initialDelaySeconds: 5
+#          # -- The timeout seconds for the readiness probe
+#          timeoutSeconds: 1
+#          # -- The period seconds for the readiness probe
+#          periodSeconds: 10
+#          # -- The success threshold for the readiness probe
+#          successThreshold: 1
+#          # -- The failure threshold for the readiness probe
+#          failureThreshold: 3
 
       # -- The config for readiness probe of the main container
       readinessProbe: {}
@@ -532,6 +603,24 @@ flownode:
 
       # -- The pod volumeMounts
       volumeMounts: []
+
+      # -- The config for startup probe of the main container
+      startupProbe: {}
+#        httpGet:
+#          # -- Path to access on the HTTP server
+#          path: /health
+#          # -- Name or number of the port to access on the container
+#          port: 4000
+#          # -- The initial delay seconds for the readiness probe.
+#          initialDelaySeconds: 5
+#          # -- The timeout seconds for the readiness probe
+#          timeoutSeconds: 1
+#          # -- The period seconds for the readiness probe
+#          periodSeconds: 10
+#          # -- The success threshold for the readiness probe
+#          successThreshold: 1
+#          # -- The failure threshold for the readiness probe
+#          failureThreshold: 3
 
       # -- The config for readiness probe of the main container
       readinessProbe: {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Incremented version of the GreptimeDB cluster Helm chart to 0.2.28.
	- Added `startupProbe` configurations to enhance health checks for various pod templates (base, datanode, flownode, frontend, and meta).

- **Documentation**
	- Updated README to reflect the new version and added `startupProbe` details.

- **Configuration**
	- Introduced `startupProbe` in the `values.yaml` file for multiple components, providing a placeholder for future configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->