### PR TITLE
docs: remove `... > connections.out &` part when use `kubectl port-forward`

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ If you want to deploy the GreptimeDB cluster, you can use the following commands
 
    ```console
    # You can use the MySQL or PostgreSQL client to connect the cluster, for example: 'mysql -h 127.0.0.1 -P 4002'.
-   kubectl port-forward -n default svc/mycluster-frontend 4001:4001 4002:4002 4003:4003 4000:4000 > connections.out &
+   kubectl port-forward -n default svc/mycluster-frontend 4001:4001 4002:4002 4003:4003 4000:4000
    ```
 
    If you want to expose the service to the public, you can use the `kubectl port-forward` command with the `--address` option:
 
    ```console
-   kubectl port-forward --address 0.0.0.0 svc/mycluster-frontend 4001:4001 4002:4002 4003:4003 4000:4000 > connections.txt &
+   kubectl port-forward --address 0.0.0.0 svc/mycluster-frontend 4001:4001 4002:4002 4003:4003 4000:4000
    ```
 
    You can also read and write data using refer to the [docs](https://docs.greptime.com/user-guide/cluster).

--- a/charts/greptimedb-standalone/Chart.yaml
+++ b/charts/greptimedb-standalone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-standalone
 description: A Helm chart for deploying standalone greptimedb
 type: application
-version: 0.1.31
+version: 0.1.32
 appVersion: 0.9.5
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying standalone greptimedb
 
-![Version: 0.1.31](https://img.shields.io/badge/Version-0.1.31-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
+![Version: 0.1.32](https://img.shields.io/badge/Version-0.1.32-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
 
 ## Source Code
 - https://github.com/GreptimeTeam/greptimedb
@@ -34,10 +34,10 @@ helm upgrade --install greptimedb-standalone greptime/greptimedb-standalone \
 
 ```console
 # You can use the MySQL client to connect the greptimedb, for example: 'mysql -h 127.0.0.1 -P 4002'.
-kubectl port-forward -n default svc/greptimedb-standalone 4002:4002 > connections.out &
+kubectl port-forward -n default svc/greptimedb-standalone 4002:4002
 
 # You can use the PostgreSQL client to connect the greptimedb, for example: 'psql -h 127.0.0.1 -p 4003 -d public'.
-kubectl port-forward -n default svc/greptimedb-standalone 4003:4003 > connections.out &
+kubectl port-forward -n default svc/greptimedb-standalone 4003:4003
 ```
 
 ## How to uninstall

--- a/charts/greptimedb-standalone/README.md.gotmpl
+++ b/charts/greptimedb-standalone/README.md.gotmpl
@@ -33,10 +33,10 @@ helm upgrade --install greptimedb-standalone greptime/greptimedb-standalone \
 
 ```console
 # You can use the MySQL client to connect the greptimedb, for example: 'mysql -h 127.0.0.1 -P 4002'.
-kubectl port-forward -n default svc/greptimedb-standalone 4002:4002 > connections.out &
+kubectl port-forward -n default svc/greptimedb-standalone 4002:4002
 
 # You can use the PostgreSQL client to connect the greptimedb, for example: 'psql -h 127.0.0.1 -p 4003 -d public'.
-kubectl port-forward -n default svc/greptimedb-standalone 4003:4003 > connections.out &
+kubectl port-forward -n default svc/greptimedb-standalone 4003:4003
 ```
 
 ## How to uninstall


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version of the `greptimedb-standalone` Helm chart to 0.1.32.
- **Documentation**
	- Simplified connection instructions by removing output redirection from `kubectl port-forward` commands in README files.
	- Updated version badge in the README to reflect the new chart version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->