### PR TITLE
chore: bump greptimedb version to v0.10.1

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.2.33
-appVersion: 0.9.5
+version: 0.2.34
+appVersion: 0.10.1
 home: https://github.com/GreptimeTeam/greptimedb
 sources:
   - https://github.com/GreptimeTeam/greptimedb

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.2.33](https://img.shields.io/badge/Version-0.2.33-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
+![Version: 0.2.34](https://img.shields.io/badge/Version-0.2.34-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.1](https://img.shields.io/badge/AppVersion-0.10.1-informational?style=flat-square)
 
 ## Source Code
 
@@ -221,10 +221,10 @@ helm uninstall mycluster -n default
 | image.pullSecrets | list | `[]` | The image pull secrets |
 | image.registry | string | `"docker.io"` | The image registry |
 | image.repository | string | `"greptime/greptimedb"` | The image repository |
-| image.tag | string | `"v0.9.5"` | The image tag |
+| image.tag | string | `"v0.10.1"` | The image tag |
 | initializer.registry | string | `"docker.io"` | Initializer image registry |
 | initializer.repository | string | `"greptime/greptimedb-initializer"` | Initializer image repository |
-| initializer.tag | string | `"v0.1.3-alpha.6"` | Initializer image tag |
+| initializer.tag | string | `"v0.1.3-alpha.8"` | Initializer image tag |
 | logging | object | `{"filters":[],"format":"text","level":"info","logsDir":"/data/greptimedb/logs","onlyLogToStdout":false,"persistentWithData":false,"slowQuery":{"enabled":false,"sampleRatio":"1.0","threshold":"10s"}}` | Global logging configuration |
 | logging.filters | list | `[]` | The log filters, use the syntax of `target[span\{field=value\}]=level` to filter the logs. |
 | logging.format | string | `"text"` | The log format for greptimedb, only support "json" and "text" |

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -4,7 +4,7 @@ image:
   # -- The image repository
   repository: greptime/greptimedb
   # -- The image tag
-  tag: "v0.9.5"
+  tag: "v0.10.1"
   # -- The image pull secrets
   pullSecrets: []
 
@@ -14,7 +14,7 @@ initializer:
   # -- Initializer image repository
   repository: greptime/greptimedb-initializer
   # -- Initializer image tag
-  tag: v0.1.3-alpha.6
+  tag: v0.1.3-alpha.8
 
 base:
   # -- The pod template for base

--- a/charts/greptimedb-standalone/Chart.yaml
+++ b/charts/greptimedb-standalone/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: greptimedb-standalone
 description: A Helm chart for deploying standalone greptimedb
 type: application
-version: 0.1.32
-appVersion: 0.9.5
+version: 0.1.33
+appVersion: 0.10.1
 home: https://github.com/GreptimeTeam/greptimedb
 sources:
   - https://github.com/GreptimeTeam/greptimedb

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying standalone greptimedb
 
-![Version: 0.1.32](https://img.shields.io/badge/Version-0.1.32-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.5](https://img.shields.io/badge/AppVersion-0.9.5-informational?style=flat-square)
+![Version: 0.1.33](https://img.shields.io/badge/Version-0.1.33-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.1](https://img.shields.io/badge/AppVersion-0.10.1-informational?style=flat-square)
 
 ## Source Code
 - https://github.com/GreptimeTeam/greptimedb
@@ -66,7 +66,7 @@ helm uninstall greptimedb-standalone -n default
 | image.pullSecrets | list | `[]` | The image pull secrets. |
 | image.registry | string | `"docker.io"` | The image registry |
 | image.repository | string | `"greptime/greptimedb"` | The image repository |
-| image.tag | string | `"v0.9.5"` | The image tag |
+| image.tag | string | `"v0.10.1"` | The image tag |
 | monitoring.annotations | object | `{}` | PodMonitor annotations |
 | monitoring.enabled | bool | `false` | Enable prometheus podmonitor |
 | monitoring.interval | string | `"30s"` | PodMonitor scrape interval |

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -4,7 +4,7 @@ image:
   # -- The image repository
   repository: greptime/greptimedb
   # -- The image tag
-  tag: "v0.9.5"
+  tag: "v0.10.1"
   # -- The image pull policy for the controller
   pullPolicy: IfNotPresent
   # -- The image pull secrets.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated versions for GreptimeDB cluster and standalone Helm charts to enhance functionality.
	- New image tags for GreptimeDB and initializer images, indicating potential feature improvements or bug fixes.

- **Bug Fixes**
	- Incremented app versions may include important updates and fixes.

- **Documentation**
	- Updated README files to reflect new versioning information and image tags for both cluster and standalone charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->