### PR TITLE
feat: add jaeger-all-in-one for trouble shooting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
         run: |
           helm repo add greptime https://greptimeteam.github.io/helm-charts/
           helm repo add grafana https://grafana.github.io/helm-charts/
+          helm repo add jaeger-all-in-one https://raw.githubusercontent.com/hansehe/jaeger-all-in-one/master/helm/charts/
           helm search repo greptime
 
       - uses: actions/setup-python@v4

--- a/charts/greptimedb-cluster/Chart.lock
+++ b/charts/greptimedb-cluster/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 8.5.8
-digest: sha256:b179fe8efb2cf11a027a8c49ee1cba728dab1be054f625c92fc9fdfffd0f1ab5
-generated: "2024-10-26T14:46:51.314884+08:00"
+- name: jaeger-all-in-one
+  repository: https://raw.githubusercontent.com/hansehe/jaeger-all-in-one/master/helm/charts
+  version: 0.1.12
+digest: sha256:e260d018c3781656e59282e609718348d11d82d9d8b3126f57761974b8c9b70f
+generated: "2024-11-28T10:39:55.943979+08:00"

--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.2.36
+version: 0.2.37
 appVersion: 0.10.2
 home: https://github.com/GreptimeTeam/greptimedb
 sources:
@@ -23,3 +23,10 @@ dependencies:
     version: "8.5.8"
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
+
+  # TODO(zyy17): Should we use the official Jaeger chart: https://github.com/jaegertracing/helm-charts/tree/main in the future?
+  # The main function of the current chart is the same as the official one, but more lightweight and easy to use.
+  - name: jaeger-all-in-one
+    version: 0.1.12
+    repository: https://raw.githubusercontent.com/hansehe/jaeger-all-in-one/master/helm/charts
+    condition: jaeger-all-in-one.enabled

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.2.36](https://img.shields.io/badge/Version-0.2.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.2](https://img.shields.io/badge/AppVersion-0.10.2-informational?style=flat-square)
+![Version: 0.2.37](https://img.shields.io/badge/Version-0.2.37-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.2](https://img.shields.io/badge/AppVersion-0.10.2-informational?style=flat-square)
 
 ## Source Code
 
@@ -74,6 +74,7 @@ helm uninstall mycluster -n default
 | Repository | Name | Version |
 |------------|------|---------|
 | https://grafana.github.io/helm-charts | grafana | 8.5.8 |
+| https://raw.githubusercontent.com/hansehe/jaeger-all-in-one/master/helm/charts | jaeger-all-in-one | 0.1.12 |
 
 ## Values
 
@@ -225,6 +226,23 @@ helm uninstall mycluster -n default
 | initializer.registry | string | `"docker.io"` | Initializer image registry |
 | initializer.repository | string | `"greptime/greptimedb-initializer"` | Initializer image repository |
 | initializer.tag | string | `"v0.1.3"` | Initializer image tag |
+| jaeger-all-in-one | object | `{"enableHttpOpenTelemetryCollector":true,"enableHttpZipkinCollector":true,"enabled":false,"image":{"pullPolicy":"IfNotPresent","repository":"jaegertracing/all-in-one","versionOverride":"latest"},"resources":{},"service":{"annotations":{},"port":16686,"type":"ClusterIP"},"volume":{"className":"","enabled":true,"size":"3Gi"}}` | Deploy jaeger-all-in-one for development purpose. |
+| jaeger-all-in-one.enableHttpOpenTelemetryCollector | bool | `true` | Enable the opentelemetry collector for jaeger-all-in-one and listen on port 4317. |
+| jaeger-all-in-one.enableHttpZipkinCollector | bool | `true` | Enable the zipkin collector for jaeger-all-in-one and listen on port 9411. |
+| jaeger-all-in-one.enabled | bool | `false` | Enable jaeger-all-in-one deployment. |
+| jaeger-all-in-one.image | object | `{"pullPolicy":"IfNotPresent","repository":"jaegertracing/all-in-one","versionOverride":"latest"}` | The jaeger-all-in-one image configuration. |
+| jaeger-all-in-one.image.pullPolicy | string | `"IfNotPresent"` | The jaeger-all-in-one image pull policy. |
+| jaeger-all-in-one.image.repository | string | `"jaegertracing/all-in-one"` | The jaeger-all-in-one image repository. |
+| jaeger-all-in-one.image.versionOverride | string | `"latest"` | The jaeger-all-in-one image tag. |
+| jaeger-all-in-one.resources | object | `{}` | The resources configurations for the jaeger-all-in-one. |
+| jaeger-all-in-one.service | object | `{"annotations":{},"port":16686,"type":"ClusterIP"}` | The jaeger-all-in-one service configuration. |
+| jaeger-all-in-one.service.annotations | object | `{}` | The annotations for the service. |
+| jaeger-all-in-one.service.port | int | `16686` | The service port. |
+| jaeger-all-in-one.service.type | string | `"ClusterIP"` | The type of the service. |
+| jaeger-all-in-one.volume | object | `{"className":"","enabled":true,"size":"3Gi"}` | The jaeger-all-in-one persistence configuration. |
+| jaeger-all-in-one.volume.className | string | `""` | The storageclass for the jaeger-all-in-one. |
+| jaeger-all-in-one.volume.enabled | bool | `true` | Whether to enable the persistence for jaeger-all-in-one. |
+| jaeger-all-in-one.volume.size | string | `"3Gi"` | The storage size for the jaeger-all-in-one. |
 | logging | object | `{"filters":[],"format":"text","level":"info","logsDir":"/data/greptimedb/logs","onlyLogToStdout":false,"persistentWithData":false,"slowQuery":{"enabled":false,"sampleRatio":"1.0","threshold":"10s"}}` | Global logging configuration |
 | logging.filters | list | `[]` | The log filters, use the syntax of `target[span\{field=value\}]=level` to filter the logs. |
 | logging.format | string | `"text"` | The log format for greptimedb, only support "json" and "text" |

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -1024,3 +1024,50 @@ grafana:
     type: ClusterIP
     # -- The annotations for the grafana service.
     annotations: {}
+
+# -- Deploy jaeger-all-in-one for development purpose.
+jaeger-all-in-one:
+  # -- Enable jaeger-all-in-one deployment.
+  enabled: false
+
+  # -- The jaeger-all-in-one image configuration.
+  image:
+    # -- The jaeger-all-in-one image repository.
+    repository: jaegertracing/all-in-one
+    # -- The jaeger-all-in-one image pull policy.
+    pullPolicy: IfNotPresent
+    # -- The jaeger-all-in-one image tag.
+    versionOverride: latest
+
+  # -- The jaeger-all-in-one service configuration.
+  service:
+    # -- The type of the service.
+    type: ClusterIP
+    # -- The service port.
+    port: 16686
+    # -- The annotations for the service.
+    annotations: {}
+
+  # -- The jaeger-all-in-one persistence configuration.
+  volume:
+    # -- Whether to enable the persistence for jaeger-all-in-one.
+    enabled: true
+    # -- The storageclass for the jaeger-all-in-one.
+    className: ""
+    # -- The storage size for the jaeger-all-in-one.
+    size: 3Gi
+
+  # -- Enable the zipkin collector for jaeger-all-in-one and listen on port 9411.
+  enableHttpZipkinCollector: true
+
+  # -- Enable the opentelemetry collector for jaeger-all-in-one and listen on port 4317.
+  enableHttpOpenTelemetryCollector: true
+
+  # -- The resources configurations for the jaeger-all-in-one.
+  resources: {}
+#    limits:
+#     cpu: 100m
+#     memory: 128Mi
+#    requests:
+#     cpu: 100m
+#     memory: 128Mi

--- a/scripts/e2e/greptimedb-cluster.sh
+++ b/scripts/e2e/greptimedb-cluster.sh
@@ -54,6 +54,7 @@ function drop_table() {
 function deploy_greptimedb_cluster() {
   # Handle greptimedb-cluster dependencies.
   helm repo add grafana https://grafana.github.io/helm-charts --force-update
+  helm repo add jaeger-all-in-one https://raw.githubusercontent.com/hansehe/jaeger-all-in-one/master/helm/charts --force-update
   helm dependency build charts/greptimedb-cluster
 
   # Deploy greptimedb cluster.

--- a/scripts/release/release-charts-to-acr.sh
+++ b/scripts/release/release-charts-to-acr.sh
@@ -13,6 +13,7 @@ for dir in "$CHARTS_DIR"/*; do
     if [ "$chart_name" == "greptimedb-cluster" ]; then
       # Use the OCI registry URL as the repository in the Chart.yaml file.
       sed -i 's|https://grafana.github.io/helm-charts|oci://greptime-registry.cn-hangzhou.cr.aliyuncs.com/charts|g' "$dir/Chart.yaml"
+      sed -i 's|https://raw.githubusercontent.com/hansehe/jaeger-all-in-one/master/helm/charts|oci://greptime-registry.cn-hangzhou.cr.aliyuncs.com/charts|g' "$dir/Chart.yaml"
 
       # Update the dependencies.
       helm dependency update "$dir"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `greptimedb-cluster` Helm chart to version `0.2.37`.
	- Introduced a new dependency on `jaeger-all-in-one` for enhanced tracing capabilities.
	- Added configuration options for `jaeger-all-in-one`, including deployment enablement and image settings.

- **Documentation**
	- Updated README to reflect new version and added details on the `jaeger-all-in-one` configuration options.

- **Chores**
	- Modified release script to update URLs for the Jaeger chart in the `Chart.yaml`.
	- Enhanced CI workflow to include Jaeger Helm chart repository.
	- Updated deployment script to include Jaeger Helm repository for smoother deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->