### PR TITLE
chore: bump greptimedb version to v0.11.0

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.2.39
-appVersion: 0.10.2
+version: 0.2.40
+appVersion: 0.11.0
 home: https://github.com/GreptimeTeam/greptimedb
 sources:
   - https://github.com/GreptimeTeam/greptimedb

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.2.39](https://img.shields.io/badge/Version-0.2.39-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.2](https://img.shields.io/badge/AppVersion-0.10.2-informational?style=flat-square)
+![Version: 0.2.40](https://img.shields.io/badge/Version-0.2.40-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 ## Source Code
 
@@ -222,7 +222,7 @@ helm uninstall mycluster -n default
 | image.pullSecrets | list | `[]` | The image pull secrets |
 | image.registry | string | `"docker.io"` | The image registry |
 | image.repository | string | `"greptime/greptimedb"` | The image repository |
-| image.tag | string | `"v0.10.2"` | The image tag |
+| image.tag | string | `"v0.11.0"` | The image tag |
 | initializer.registry | string | `"docker.io"` | Initializer image registry |
 | initializer.repository | string | `"greptime/greptimedb-initializer"` | Initializer image repository |
 | initializer.tag | string | `"v0.1.4-alpha.2"` | Initializer image tag |

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -4,7 +4,7 @@ image:
   # -- The image repository
   repository: greptime/greptimedb
   # -- The image tag
-  tag: "v0.10.2"
+  tag: "v0.11.0"
   # -- The image pull secrets
   pullSecrets: []
 

--- a/charts/greptimedb-standalone/Chart.yaml
+++ b/charts/greptimedb-standalone/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: greptimedb-standalone
 description: A Helm chart for deploying standalone greptimedb
 type: application
-version: 0.1.35
-appVersion: 0.10.2
+version: 0.1.36
+appVersion: 0.11.0
 home: https://github.com/GreptimeTeam/greptimedb
 sources:
   - https://github.com/GreptimeTeam/greptimedb

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying standalone greptimedb
 
-![Version: 0.1.35](https://img.shields.io/badge/Version-0.1.35-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.2](https://img.shields.io/badge/AppVersion-0.10.2-informational?style=flat-square)
+![Version: 0.1.36](https://img.shields.io/badge/Version-0.1.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 ## Source Code
 - https://github.com/GreptimeTeam/greptimedb
@@ -66,7 +66,7 @@ helm uninstall greptimedb-standalone -n default
 | image.pullSecrets | list | `[]` | The image pull secrets. |
 | image.registry | string | `"docker.io"` | The image registry |
 | image.repository | string | `"greptime/greptimedb"` | The image repository |
-| image.tag | string | `"v0.10.2"` | The image tag |
+| image.tag | string | `"v0.11.0"` | The image tag |
 | monitoring.annotations | object | `{}` | PodMonitor annotations |
 | monitoring.enabled | bool | `false` | Enable prometheus podmonitor |
 | monitoring.interval | string | `"30s"` | PodMonitor scrape interval |

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -4,7 +4,7 @@ image:
   # -- The image repository
   repository: greptime/greptimedb
   # -- The image tag
-  tag: "v0.10.2"
+  tag: "v0.11.0"
   # -- The image pull policy for the controller
   pullPolicy: IfNotPresent
   # -- The image pull secrets.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated versions for the `greptimedb-cluster` and `greptimedb-standalone` Helm charts to `0.2.40` and `0.1.36`, respectively.
	- Updated application version to `0.11.0` for both clusters.
	- Updated Docker image tags to `v0.11.0` for GreptimeDB in both clusters.

- **Documentation**
	- Revised README files to reflect new version numbers and image tags for both Helm charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->