### PR TITLE
feat(greptimedb-standalone): add static auth configuration

### DIFF
--- a/charts/greptimedb-standalone/Chart.yaml
+++ b/charts/greptimedb-standalone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-standalone
 description: A Helm chart for deploying standalone greptimedb
 type: application
-version: 0.1.36
+version: 0.1.37
 appVersion: 0.11.0
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying standalone greptimedb
 
-![Version: 0.1.36](https://img.shields.io/badge/Version-0.1.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 0.1.37](https://img.shields.io/badge/Version-0.1.37-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 ## Source Code
 - https://github.com/GreptimeTeam/greptimedb
@@ -53,6 +53,11 @@ helm uninstall greptimedb-standalone -n default
 | affinity | object | `{}` | Affinity configuration for pod |
 | annotations | object | `{}` | The annotations |
 | args | list | `[]` | The container args |
+| auth | object | `{"enabled":false,"fileName":"passwd","mountPath":"/etc/greptimedb/auth","users":[{"password":"admin","username":"admin"}]}` | The static auth for greptimedb, only support one user now(https://docs.greptime.com/user-guide/deployments/authentication/static). |
+| auth.enabled | bool | `false` | Enable static auth |
+| auth.fileName | string | `"passwd"` | The auth file name, the full path is `${mountPath}/${fileName}` |
+| auth.mountPath | string | `"/etc/greptimedb/auth"` | The auth file path to store the auth info |
+| auth.users | list | `[{"password":"admin","username":"admin"}]` | The users to be created in the auth file |
 | command | list | `[]` | The container command |
 | configToml | string | `"mode = 'standalone'\n"` | The extra configuration for greptimedb |
 | dataHome | string | `"/data/greptimedb/"` | Storage root directory |

--- a/charts/greptimedb-standalone/templates/statefulset.yaml
+++ b/charts/greptimedb-standalone/templates/statefulset.yaml
@@ -64,7 +64,7 @@ spec:
           args:
             {{- if .Values.configToml }}
             - "--config-file"
-            - "/etc/greptimedb/config.toml"
+            - "/etc/greptimedb/config/config.toml"
             {{- end }}
             {{- if .Values.dataHome }}
             - "--data-home"
@@ -86,11 +86,15 @@ spec:
             - containerPort: {{ .Values.postgresServicePort }}
               name: postgres
               protocol: TCP
-          {{- if .Values.env }}
+          {{- if or .Values.env .Values.auth.enabled }}
           env:
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}
+            {{- end }}
+            {{- if .Values.auth.enabled }}
+            - name: GREPTIMEDB_STANDALONE__USER_PROVIDER
+              value: "static_user_provider:file:{{ .Values.auth.mountPath }}/{{ .Values.auth.fileName }}"
             {{- end }}
           {{- end }}
           {{- if .Values.objectStorage }}
@@ -113,7 +117,12 @@ spec:
               mountPath: {{ .Values.persistence.mountPath }}
             {{- if .Values.configToml }}
             - name: config
-              mountPath: /etc/greptimedb
+              mountPath: /etc/greptimedb/config
+              readOnly: true
+            {{- end }}
+            {{- if .Values.auth.enabled }}
+            - name: auth
+              mountPath: {{ .Values.auth.mountPath }}
               readOnly: true
             {{- end }}
             {{- with .Values.extraVolumeMounts }}
@@ -123,17 +132,20 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if or .Values.configToml .Values.extraVolumes }}
       volumes:
         {{- if .Values.configToml }}
         - name: config
           configMap:
             name: {{ include "greptimedb-standalone.fullname" . }}-config
         {{- end }}
+        {{- if .Values.auth.enabled }}
+        - name: auth
+          secret:
+            secretName: {{ include "greptimedb-standalone.fullname" . }}-users-auth
+        {{- end }}
         {{- with .Values.extraVolumes }}
             {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/greptimedb-standalone/templates/users-auth-secret.yaml
+++ b/charts/greptimedb-standalone/templates/users-auth-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.auth.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "greptimedb-standalone.fullname" . }}-users-auth
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  {{ .Values.auth.fileName }}: |
+    {{- range .Values.auth.users }}
+    {{ printf "%s=%s" .username .password }}
+    {{- end }}
+{{- end }}

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -239,3 +239,16 @@ service:
   type: ClusterIP
   # -- Annotations for service
   annotations: {}
+
+# -- The static auth for greptimedb, only support one user now(https://docs.greptime.com/user-guide/deployments/authentication/static).
+auth:
+  # -- Enable static auth
+  enabled: false
+  # -- The auth file path to store the auth info
+  mountPath: "/etc/greptimedb/auth"
+  # -- The auth file name, the full path is `${mountPath}/${fileName}`
+  fileName: "passwd"
+  # -- The users to be created in the auth file
+  users:
+    - username: "admin"
+      password: "admin"


### PR DESCRIPTION
Configure static authentication using username and password to connect to GreptimeDB:
```
# mysql -h 127.0.0.1 -P 4002 -u admin -p
Enter password: // is admin by default
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 8
Server version: 8.4.2 Greptime

Copyright (c) 2000, 2022, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> exit
Bye
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version of the `greptimedb-standalone` Helm chart to `0.1.37`.
	- Introduced new configuration options for static authentication, allowing users to enable and configure authentication settings.

- **Bug Fixes**
	- Corrected the configuration file path in the Kubernetes deployment.

- **Chores**
	- Added a new Kubernetes Secret for managing user credentials based on authentication settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->