### PR TITLE
feat: Add additional labels to the kubernetes resources

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.2.43
+version: 0.2.45
 appVersion: 0.11.2
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.2.43](https://img.shields.io/badge/Version-0.2.43-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.2](https://img.shields.io/badge/AppVersion-0.11.2-informational?style=flat-square)
+![Version: 0.2.45](https://img.shields.io/badge/Version-0.2.45-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.2](https://img.shields.io/badge/AppVersion-0.11.2-informational?style=flat-square)
 
 ## Source Code
 
@@ -80,6 +80,7 @@ helm uninstall mycluster -n default
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| additionalLabels | object | `{}` | additional labels to add to all resources |
 | auth | object | `{"enabled":false,"fileName":"passwd","mountPath":"/etc/greptimedb/auth","users":[{"password":"admin","username":"admin"}]}` | The static auth for greptimedb, only support one user now(https://docs.greptime.com/user-guide/deployments/authentication/static). |
 | auth.enabled | bool | `false` | Enable static auth |
 | auth.fileName | string | `"passwd"` | The auth file name, the full path is `${mountPath}/${fileName}` |

--- a/charts/greptimedb-cluster/templates/_helpers.tpl
+++ b/charts/greptimedb-cluster/templates/_helpers.tpl
@@ -1,0 +1,64 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "greptimedb-cluster.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "greptimedb-cluster.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "greptimedb-cluster.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "greptimedb-cluster.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "greptimedb-cluster.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "greptimedb-cluster.labels" -}}
+helm.sh/chart: {{ include "greptimedb-cluster.chart" . }}
+{{ include "greptimedb-cluster.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/component: greptimedb-cluster
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "greptimedb-cluster.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "greptimedb-cluster.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/greptimedb-cluster/templates/_helpers.tpl
+++ b/charts/greptimedb-cluster/templates/_helpers.tpl
@@ -54,6 +54,9 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/component: cluster
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: greptimedb-cluster
+{{- with .Values.additionalLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/greptimedb-cluster/templates/_helpers.tpl
+++ b/charts/greptimedb-cluster/templates/_helpers.tpl
@@ -51,8 +51,9 @@ helm.sh/chart: {{ include "greptimedb-cluster.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: greptimedb-cluster
+app.kubernetes.io/component: cluster
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: greptimedb-cluster
 {{- end }}
 
 {{/*

--- a/charts/greptimedb-cluster/templates/cluster.yaml
+++ b/charts/greptimedb-cluster/templates/cluster.yaml
@@ -3,6 +3,8 @@ kind: GreptimeDBCluster
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-cluster.labels" . | nindent 4 }}
 spec:
   base:
     main:

--- a/charts/greptimedb-cluster/templates/debug-depoyment.yaml
+++ b/charts/greptimedb-cluster/templates/debug-depoyment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Release.Name }}-debug-pod
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "greptimedb-cluster.labels" . | nindent 4 }}
     app: {{ .Release.Name }}-debug-pod
 spec:
   replicas: 1

--- a/charts/greptimedb-cluster/templates/grafana-dashboards-configmap.yaml
+++ b/charts/greptimedb-cluster/templates/grafana-dashboards-configmap.yaml
@@ -6,6 +6,8 @@ kind: ConfigMap
 metadata:
   name: {{ $value }}
   namespace: {{ $root.Release.Namespace }}
+  labels:
+    {{- include "greptimedb-cluster.labels" . | nindent 4 }}
 data:
   {{ $key }}.json: |-
 {{ $root.Files.Get (printf "dashboards/%s.json" $key) | indent 4 }}

--- a/charts/greptimedb-cluster/templates/grafana-dashboards-configmap.yaml
+++ b/charts/greptimedb-cluster/templates/grafana-dashboards-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ $value }}
   namespace: {{ $root.Release.Namespace }}
   labels:
-    {{- include "greptimedb-cluster.labels" . | nindent 4 }}
+    {{- include "greptimedb-cluster.labels" $root | nindent 4 }}
 data:
   {{ $key }}.json: |-
 {{ $root.Files.Get (printf "dashboards/%s.json" $key) | indent 4 }}

--- a/charts/greptimedb-cluster/templates/secret.yaml
+++ b/charts/greptimedb-cluster/templates/secret.yaml
@@ -5,6 +5,8 @@ apiVersion: v1
 metadata:
   name: {{ default "storage-credentials" .Values.objectStorage.credentials.secretName }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-cluster.labels" . | nindent 4 }}
 kind: Secret
 type: Opaque
 {{- if .Values.objectStorage.credentials.serviceAccountKey }}

--- a/charts/greptimedb-cluster/templates/serviceaccount-datanode.yaml
+++ b/charts/greptimedb-cluster/templates/serviceaccount-datanode.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-datanode
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-cluster.labels" . | nindent 4 }}
   {{- with .Values.datanode.podTemplate.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/greptimedb-cluster/templates/serviceaccount-flownode.yaml
+++ b/charts/greptimedb-cluster/templates/serviceaccount-flownode.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-flownode
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-cluster.labels" . | nindent 4 }}
   {{- with .Values.flownode.podTemplate.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/greptimedb-cluster/templates/serviceaccount-frontend.yaml
+++ b/charts/greptimedb-cluster/templates/serviceaccount-frontend.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-frontend
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-cluster.labels" . | nindent 4 }}
   {{- with .Values.frontend.podTemplate.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/greptimedb-cluster/templates/serviceaccount-meta.yaml
+++ b/charts/greptimedb-cluster/templates/serviceaccount-meta.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-meta
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-cluster.labels" . | nindent 4 }}
   {{- with .Values.meta.podTemplate.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/greptimedb-cluster/templates/users-auth-secret.yaml
+++ b/charts/greptimedb-cluster/templates/users-auth-secret.yaml
@@ -4,6 +4,8 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-users-auth
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-cluster.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   {{ .Values.auth.fileName }}: |

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -8,6 +8,9 @@ image:
   # -- The image pull secrets
   pullSecrets: []
 
+# -- additional labels to add to all resources
+additionalLabels: {}
+
 initializer:
   # -- Initializer image registry
   registry: docker.io

--- a/charts/greptimedb-operator/Chart.yaml
+++ b/charts/greptimedb-operator/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.18.0-0"
 description: The greptimedb-operator Helm chart for Kubernetes.
 name: greptimedb-operator
 appVersion: 0.1.4-alpha.2
-version: 0.2.14
+version: 0.2.16
 type: application
 home: https://github.com/GreptimeTeam/greptimedb-operator
 sources:

--- a/charts/greptimedb-operator/README.md
+++ b/charts/greptimedb-operator/README.md
@@ -2,7 +2,7 @@
 
 The greptimedb-operator Helm chart for Kubernetes.
 
-![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.4-alpha.2](https://img.shields.io/badge/AppVersion-0.1.4--alpha.2-informational?style=flat-square)
+![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.4-alpha.3](https://img.shields.io/badge/AppVersion-0.1.4--alpha.3-informational?style=flat-square)
 
 ## Source Code
 

--- a/charts/greptimedb-operator/README.md
+++ b/charts/greptimedb-operator/README.md
@@ -2,7 +2,7 @@
 
 The greptimedb-operator Helm chart for Kubernetes.
 
-![Version: 0.2.14](https://img.shields.io/badge/Version-0.2.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.4-alpha.2](https://img.shields.io/badge/AppVersion-0.1.4--alpha.2-informational?style=flat-square)
+![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.4-alpha.2](https://img.shields.io/badge/AppVersion-0.1.4--alpha.2-informational?style=flat-square)
 
 ## Source Code
 
@@ -100,6 +100,7 @@ Kubernetes: `>=1.18.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| additionalLabels | object | `{}` | additional labels to add to all resources |
 | affinity | object | `{}` | The pod affinity |
 | apiServer | object | `{"enabled":false,"podMetrics":{"enabled":false},"port":8081}` | The configuration for the operator API server |
 | apiServer.enabled | bool | `false` | Whether to enable the API server |

--- a/charts/greptimedb-operator/templates/_helpers.tpl
+++ b/charts/greptimedb-operator/templates/_helpers.tpl
@@ -51,7 +51,7 @@ helm.sh/chart: {{ include "greptimedb-operator.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: operator
+app.kubernetes.io/component: greptimedb-operator
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/greptimedb-operator/templates/_helpers.tpl
+++ b/charts/greptimedb-operator/templates/_helpers.tpl
@@ -51,6 +51,7 @@ helm.sh/chart: {{ include "greptimedb-operator.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+app.kubernetes.io/component: operator
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/greptimedb-operator/templates/_helpers.tpl
+++ b/charts/greptimedb-operator/templates/_helpers.tpl
@@ -51,8 +51,9 @@ helm.sh/chart: {{ include "greptimedb-operator.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: greptimedb-operator
+app.kubernetes.io/component: operator
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/parrt-of: greptimedb-operator
 {{- end }}
 
 {{/*

--- a/charts/greptimedb-operator/templates/_helpers.tpl
+++ b/charts/greptimedb-operator/templates/_helpers.tpl
@@ -53,7 +53,10 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/component: operator
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/parrt-of: greptimedb-operator
+app.kubernetes.io/part-of: greptimedb-operator
+{{- with .Values.additionalLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/greptimedb-operator/templates/clusterrole.yaml
+++ b/charts/greptimedb-operator/templates/clusterrole.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "greptimedb-operator.fullname" . }}-role
+  labels:
+    {{- include "greptimedb-operator.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - apiextensions.k8s.io

--- a/charts/greptimedb-operator/templates/clusterrolebinding.yaml
+++ b/charts/greptimedb-operator/templates/clusterrolebinding.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "greptimedb-operator.fullname" . }}-rolebinding
+  labels:
+    {{- include "greptimedb-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/greptimedb-operator/templates/role.yaml
+++ b/charts/greptimedb-operator/templates/role.yaml
@@ -4,6 +4,8 @@ kind: Role
 metadata:
   name: {{ include "greptimedb-operator.fullname" . }}-leader-election-role
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-operator.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''

--- a/charts/greptimedb-operator/templates/rolebinding.yaml
+++ b/charts/greptimedb-operator/templates/rolebinding.yaml
@@ -4,6 +4,8 @@ kind: RoleBinding
 metadata:
   name: {{ include "greptimedb-operator.fullname" . }}-leader-election-rolebinding
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/greptimedb-operator/templates/service.yaml
+++ b/charts/greptimedb-operator/templates/service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: {{ include "greptimedb-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-operator.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   selector:

--- a/charts/greptimedb-operator/templates/serviceaccount.yaml
+++ b/charts/greptimedb-operator/templates/serviceaccount.yaml
@@ -4,4 +4,6 @@ kind: ServiceAccount
 metadata:
   name: {{ include "greptimedb-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-operator.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/greptimedb-operator/values.yaml
+++ b/charts/greptimedb-operator/values.yaml
@@ -12,6 +12,9 @@ image:
   # -- The image pull secrets
   pullSecrets: []
 
+# -- additional labels to add to all resources
+additionalLabels: {}
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true

--- a/charts/greptimedb-standalone/Chart.yaml
+++ b/charts/greptimedb-standalone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-standalone
 description: A Helm chart for deploying standalone greptimedb
 type: application
-version: 0.1.39
+version: 0.1.40
 appVersion: 0.11.2
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying standalone greptimedb
 
-![Version: 0.1.39](https://img.shields.io/badge/Version-0.1.39-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.2](https://img.shields.io/badge/AppVersion-0.11.2-informational?style=flat-square)
+![Version: 0.1.40](https://img.shields.io/badge/Version-0.1.40-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.2](https://img.shields.io/badge/AppVersion-0.11.2-informational?style=flat-square)
 
 ## Source Code
 - https://github.com/GreptimeTeam/greptimedb
@@ -50,6 +50,7 @@ helm uninstall greptimedb-standalone -n default
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| additionalLabels | object | `{}` | additional labels to add to all resources |
 | affinity | object | `{}` | Affinity configuration for pod |
 | annotations | object | `{}` | The annotations |
 | args | list | `[]` | The container args |

--- a/charts/greptimedb-standalone/templates/_helpers.tpl
+++ b/charts/greptimedb-standalone/templates/_helpers.tpl
@@ -39,6 +39,7 @@ helm.sh/chart: {{ include "greptimedb-standalone.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+app.kubernetes.io/component: greptimedb-standalone
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/greptimedb-standalone/templates/_helpers.tpl
+++ b/charts/greptimedb-standalone/templates/_helpers.tpl
@@ -39,8 +39,9 @@ helm.sh/chart: {{ include "greptimedb-standalone.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: greptimedb-standalone
+app.kubernetes.io/component: standalone
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: greptimedb-standalone
 {{- end }}
 
 {{/*

--- a/charts/greptimedb-standalone/templates/_helpers.tpl
+++ b/charts/greptimedb-standalone/templates/_helpers.tpl
@@ -42,6 +42,9 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/component: standalone
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: greptimedb-standalone
+{{- with .Values.additionalLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/greptimedb-standalone/templates/podmonitor.yaml
+++ b/charts/greptimedb-standalone/templates/podmonitor.yaml
@@ -4,10 +4,11 @@ kind: PodMonitor
 metadata:
   name: {{ include "greptimedb-standalone.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.monitoring.labels }}
   labels:
+    {{- include "greptimedb-standalone.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.labels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
   {{- with .Values.monitoring.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/greptimedb-standalone/templates/secret.yaml
+++ b/charts/greptimedb-standalone/templates/secret.yaml
@@ -5,6 +5,8 @@ apiVersion: v1
 metadata:
   name: {{ include "greptimedb-standalone.fullname" . }}-secret
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-standalone.labels" . | nindent 4 }}
 kind: Secret
 type: Opaque
 {{- if .Values.objectStorage.credentials.serviceAccountKey }}

--- a/charts/greptimedb-standalone/templates/users-auth-secret.yaml
+++ b/charts/greptimedb-standalone/templates/users-auth-secret.yaml
@@ -4,6 +4,8 @@ kind: Secret
 metadata:
   name: {{ include "greptimedb-standalone.fullname" . }}-users-auth
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-standalone.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   {{ .Values.auth.fileName }}: |

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -16,6 +16,9 @@ nameOverride: ""
 # -- Provide a name to substitute for the full names of resources
 fullnameOverride: ""
 
+# -- additional labels to add to all resources
+additionalLabels: {}
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
- Support for [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
- Support for additional labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for custom labels across GreptimeDB Helm charts.
	- Introduced `additionalLabels` configuration option in standalone, cluster, and operator charts.
	- Enhanced resource metadata with standardized Kubernetes labels.

- **Improvements**
	- Implemented consistent labeling strategies across different chart templates.
	- Added component and part-of labels for better resource identification.

- **Chores**
	- Updated helper templates to support dynamic label generation.
	- Refined label generation in various Kubernetes resource templates.
	- Updated version numbers in Chart.yaml and README.md files for all charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->