### PR TITLE
ci: use s5cmd upload package to s3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,14 +81,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_CN_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_CN_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.AWS_RELEASE_BUCKET_REGION }}
+      - name: Install s5cmd
+        shell: bash
+        run: |
+          wget https://github.com/peak/s5cmd/releases/download/v2.3.0/s5cmd_2.3.0_Linux-64bit.tar.gz
+          tar -xzf s5cmd_2.3.0_Linux-64bit.tar.gz
+          sudo mv s5cmd /usr/local/bin/
+          sudo chmod +x /usr/local/bin/s5cmd
 
       - name: Release charts to S3
         shell: bash
         run: |
           ./scripts/release/release-charts-to-s3.sh ${{ vars.AWS_RELEASE_BUCKET }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_CN_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_CN_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ vars.AWS_RELEASE_BUCKET_REGION }}

--- a/scripts/release/release-charts-to-s3.sh
+++ b/scripts/release/release-charts-to-s3.sh
@@ -36,16 +36,16 @@ function release_charts_to_s3() {
 
   echo "Releasing package '$package' to 's3://$GREPTIME_RELEASE_BUCKET/$RELEASE_DIR/$chart/$version'..."
 
-  aws s3 cp "$chart"/"$package" s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR"/"$chart"/"$version"/"$package"
+  s5cmd cp "$chart"/"$package" s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR"/"$chart"/"$version"/"$package"
 
   echo "Releasing package "$chart-latest.tgz" to 's3://$GREPTIME_RELEASE_BUCKET/$RELEASE_DIR/$chart/latest'..."
 
-  aws s3 cp "$chart"/"$package" s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR"/"$chart"/latest/"$chart"-latest.tgz
+  s5cmd cp "$chart"/"$package" s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR"/"$chart"/latest/"$chart"-latest.tgz
 
   echo "$version" > latest-version.txt
 
   # Create a latest-version.txt file in the chart directory.
-  aws s3 cp latest-version.txt s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR"/"$chart"/latest-version.txt
+  s5cmd cp latest-version.txt s3://"$GREPTIME_RELEASE_BUCKET"/"$RELEASE_DIR"/"$chart"/latest-version.txt
 }
 
 function main() {


### PR DESCRIPTION
Use this tool to upload: https://github.com/peak/s5cmd
This tool provides better performance by [benchmarks](https://github.com/peak/s5cmd?tab=readme-ov-file#benchmarks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined the automated release process for publishing charts by adopting a more efficient file transfer tool.
  - Adjusted environment configuration to apply secure credentials only when needed during the S3 release step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->