### PR TITLE
feat: add frontend enabled option

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.2.53
+version: 0.2.54
 appVersion: 0.12.0
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.2.53](https://img.shields.io/badge/Version-0.2.53-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.12.0](https://img.shields.io/badge/AppVersion-0.12.0-informational?style=flat-square)
+![Version: 0.2.54](https://img.shields.io/badge/Version-0.2.54-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.12.0](https://img.shields.io/badge/AppVersion-0.12.0-informational?style=flat-square)
 
 ## Source Code
 
@@ -176,7 +176,7 @@ helm uninstall mycluster -n default
 | flownode.podTemplate.tolerations | list | `[]` | The pod tolerations |
 | flownode.podTemplate.volumes | list | `[]` | The pod volumes |
 | flownode.replicas | int | `1` | Flownode replicas |
-| frontend | object | `{"configData":"","configFile":"","logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"service":{},"tls":{}}` | Frontend configure |
+| frontend | object | `{"configData":"","configFile":"","enabled":true,"logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"service":{},"tls":{}}` | Frontend configure |
 | frontend.configData | string | `""` | Extra raw toml config data of frontend. Skip if the `configFile` is used. |
 | frontend.configFile | string | `""` | Extra toml file of frontend. |
 | frontend.logging | object | `{}` | Logging configuration for frontend, if not set, it will use the global logging configuration. |

--- a/charts/greptimedb-cluster/templates/cluster.yaml
+++ b/charts/greptimedb-cluster/templates/cluster.yaml
@@ -60,7 +60,8 @@ spec:
     {{- if .Values.base.podTemplate.securityContext }}
     securityContext: {{ .Values.base.podTemplate.securityContext | toYaml | nindent 6 }}
     {{- end }}
-  {{- if not .Values.frontends }}
+  {{- if .Values.frontend }}
+  {{- if .Values.frontend.enabled }}
   frontend:
     replicas: {{ .Values.frontend.replicas }}
 {{- if or .Values.frontend.configFile .Values.frontend.configData }}
@@ -177,6 +178,7 @@ spec:
       filters: {{ .Values.frontend.logging.filters | toYaml | nindent 6 }}
       {{- end }}
     {{- end }}
+  {{- end }}
   {{- end }}
   meta:
     replicas: {{ .Values.meta.replicas }}

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -118,6 +118,8 @@ base:
 
 # -- Frontend configure
 frontend:
+  enabled: true
+
   # -- Frontend replicas
   replicas: 1
 


### PR DESCRIPTION
In the current version, we recommend using the `frontends` field to define frontend group resource, gradually replacing the `frontend` field, and adding `enabled` field to choose whether to enable the `frontend`, the `enabled` fields default is true for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the deployment package to the latest release.
  - Enhanced configuration for the frontend component, now explicitly enabled by default for streamlined activation.

- **Documentation**
  - Updated version indicators and configuration guidelines to reflect these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->