### PR TITLE
chore(greptimedb-standalone): change the environment variables to container start args

### DIFF
--- a/charts/greptimedb-standalone/Chart.yaml
+++ b/charts/greptimedb-standalone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-standalone
 description: A Helm chart for deploying standalone greptimedb
 type: application
-version: 0.1.43
+version: 0.1.44
 appVersion: 0.13.0
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -62,7 +62,7 @@ helm uninstall greptimedb-standalone -n default
 | command | list | `[]` | The container command |
 | configToml | string | `"mode = 'standalone'\n"` | The extra configuration for greptimedb |
 | dataHome | string | `"/data/greptimedb/"` | Storage root directory |
-| env | list | `[]` | Environment variables |
+| env | object | `{}` | Environment variables |
 | extraVolumeMounts | list | `[]` | Volume mounts to add to the pods |
 | extraVolumes | list | `[]` | Volumes to add to the pods |
 | fullnameOverride | string | `""` | Provide a name to substitute for the full names of resources |

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying standalone greptimedb
 
-![Version: 0.1.43](https://img.shields.io/badge/Version-0.1.43-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.0](https://img.shields.io/badge/AppVersion-0.13.0-informational?style=flat-square)
+![Version: 0.1.44](https://img.shields.io/badge/Version-0.1.44-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.0](https://img.shields.io/badge/AppVersion-0.13.0-informational?style=flat-square)
 
 ## Source Code
 - https://github.com/GreptimeTeam/greptimedb
@@ -53,7 +53,7 @@ helm uninstall greptimedb-standalone -n default
 | additionalLabels | object | `{}` | additional labels to add to all resources |
 | affinity | object | `{}` | Affinity configuration for pod |
 | annotations | object | `{}` | The annotations |
-| args | list | `[]` | The container args |
+| args | list | `["--http-addr","0.0.0.0:4000","--rpc-bind-addr","0.0.0.0:4001","--mysql-addr","0.0.0.0:4002","--postgres-addr","0.0.0.0:4003"]` | The container args |
 | auth | object | `{"enabled":false,"fileName":"passwd","mountPath":"/etc/greptimedb/auth","users":[{"password":"admin","username":"admin"}]}` | The static auth for greptimedb, only support one user now(https://docs.greptime.com/user-guide/deployments/authentication/static). |
 | auth.enabled | bool | `false` | Enable static auth |
 | auth.fileName | string | `"passwd"` | The auth file name, the full path is `${mountPath}/${fileName}` |
@@ -62,7 +62,7 @@ helm uninstall greptimedb-standalone -n default
 | command | list | `[]` | The container command |
 | configToml | string | `"mode = 'standalone'\n"` | The extra configuration for greptimedb |
 | dataHome | string | `"/data/greptimedb/"` | Storage root directory |
-| env | object | `{"GREPTIMEDB_STANDALONE__HTTP__ADDR":"0.0.0.0:4000"}` | Environment variables |
+| env | list | `[]` | Environment variables |
 | extraVolumeMounts | list | `[]` | Volume mounts to add to the pods |
 | extraVolumes | list | `[]` | Volumes to add to the pods |
 | fullnameOverride | string | `""` | Provide a name to substitute for the full names of resources |

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -53,7 +53,7 @@ helm uninstall greptimedb-standalone -n default
 | additionalLabels | object | `{}` | additional labels to add to all resources |
 | affinity | object | `{}` | Affinity configuration for pod |
 | annotations | object | `{}` | The annotations |
-| args | list | `["--http-addr","0.0.0.0:4000","--rpc-bind-addr","0.0.0.0:4001","--mysql-addr","0.0.0.0:4002","--postgres-addr","0.0.0.0:4003"]` | The container args |
+| args | list | `[]` | The container args |
 | auth | object | `{"enabled":false,"fileName":"passwd","mountPath":"/etc/greptimedb/auth","users":[{"password":"admin","username":"admin"}]}` | The static auth for greptimedb, only support one user now(https://docs.greptime.com/user-guide/deployments/authentication/static). |
 | auth.enabled | bool | `false` | Enable static auth |
 | auth.fileName | string | `"passwd"` | The auth file name, the full path is `${mountPath}/${fileName}` |

--- a/charts/greptimedb-standalone/templates/service.yaml
+++ b/charts/greptimedb-standalone/templates/service.yaml
@@ -13,19 +13,19 @@ spec:
   ports:
     - name: http
       port: {{ .Values.httpServicePort }}
-      targetPort: {{ .Values.httpServicePort }}
+      targetPort: http
       protocol: TCP
     - name: grpc
       port: {{ .Values.grpcServicePort }}
-      targetPort: {{ .Values.grpcServicePort }}
+      targetPort: grpc
       protocol: TCP
     - name: mysql
       port: {{ .Values.mysqlServicePort }}
-      targetPort: {{ .Values.mysqlServicePort }}
+      targetPort: mysql
       protocol: TCP
     - name: postgres
       port: {{ .Values.postgresServicePort }}
-      targetPort: {{ .Values.postgresServicePort }}
+      targetPort: postgres
       protocol: TCP
   selector:
     {{- include "greptimedb-standalone.selectorLabels" . | nindent 4 }}

--- a/charts/greptimedb-standalone/templates/statefulset.yaml
+++ b/charts/greptimedb-standalone/templates/statefulset.yaml
@@ -62,6 +62,14 @@ spec:
             - "start"
           {{- end }}
           args:
+            - "--http-addr"
+            - "0.0.0.0:{{ .Values.httpServicePort }}"
+            - "--rpc-bind-addr"
+            - "0.0.0.0:{{ .Values.grpcServicePort }}"
+            - "--mysql-addr"
+            - "0.0.0.0:{{ .Values.mysqlServicePort }}"
+            - "--postgres-addr"
+            - "0.0.0.0:{{ .Values.postgresServicePort }}"
             {{- if .Values.configToml }}
             - "--config-file"
             - "/etc/greptimedb/config/config.toml"

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -33,16 +33,7 @@ serviceAccount:
 command: []
 
 # -- The container args
-args: [
-  "--http-addr",
-  "0.0.0.0:4000",
-  "--rpc-bind-addr",
-  "0.0.0.0:4001",
-  "--mysql-addr",
-  "0.0.0.0:4002",
-  "--postgres-addr",
-  "0.0.0.0:4003",
-]
+args: []
 
 # -- The extra configuration for greptimedb
 configToml: |

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -33,7 +33,16 @@ serviceAccount:
 command: []
 
 # -- The container args
-args: []
+args: [
+  "--http-addr",
+  "0.0.0.0:4000",
+  "--rpc-bind-addr",
+  "0.0.0.0:4001",
+  "--mysql-addr",
+  "0.0.0.0:4002",
+  "--postgres-addr",
+  "0.0.0.0:4003",
+]
 
 # -- The extra configuration for greptimedb
 configToml: |
@@ -122,12 +131,7 @@ objectStorage:
   #  cache_capacity = ""
 
 # -- Environment variables
-env:
-  GREPTIMEDB_STANDALONE__HTTP__ADDR: "0.0.0.0:4000"
-#  GREPTIMEDB_STANDALONE__GRPC__ADDR: "0.0.0.0:4001"
-#  GREPTIMEDB_STANDALONE__MYSQL__ADDR: "0.0.0.0:4002"
-#  GREPTIMEDB_STANDALONE__POSTGRES__ADDR: "0.0.0.0:4003"
-#  GREPTIMEDB_STANDALONE__OPENTSDB__ADDR: "0.0.0.0:4242"
+env: []
 
 # -- Extra pod annotations to add
 podAnnotations: {}

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -131,7 +131,8 @@ objectStorage:
   #  cache_capacity = ""
 
 # -- Environment variables
-env: []
+env: {}
+ # envKey: "envValue"
 
 # -- Extra pod annotations to add
 podAnnotations: {}


### PR DESCRIPTION
`GREPTIMEDB_STANDALONE__HTTP__ADDR: "0.0.0.0:4000"`	->  `--http-addr 0.0.0.0:4000`
`GREPTIMEDB_STANDALONE__GRPC__ADDR: "0.0.0.0:4001"`	         -> `--rpc-bind-addr 0.0.0.0:4001`
`GREPTIMEDB_STANDALONE__MYSQL__ADDR: "0.0.0.0:4002"`	 -> `--mysql-addr 0.0.0.0:4002`
`GREPTIMEDB_STANDALONE__POSTGRES__ADDR: "0.0.0.0:4003"` -> `--postgres-addr 0.0.0.0:4003` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the deployed chart version from 0.1.43 to 0.1.44.
  - Revised the default container startup configuration to now include additional command-line arguments for specifying HTTP, RPC, MySQL, and PostgreSQL addresses.
  - Removed specific environment variable configurations from the chart.

- **Documentation**
  - Updated configuration guidance to reflect the new defaults and ensure clear instructions for deploying with the revised parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->