### PR TITLE
chore: bump debug pod version to 20250317-5281e66

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: 0.13.0
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.0](https://img.shields.io/badge/AppVersion-0.13.0-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.0](https://img.shields.io/badge/AppVersion-0.13.0-informational?style=flat-square)
 
 ## Source Code
 
@@ -146,7 +146,7 @@ helm uninstall mycluster -n default
 | datanode.storage.storageRetainPolicy | string | `"Retain"` | Storage retain policy for datanode persistent volume |
 | datanode.storage.storageSize | string | `"10Gi"` | Storage size for datanode persistent volume |
 | debugPod.enabled | bool | `false` | Enable debug pod, for more information see: "../../docker/debug-pod/README.md". |
-| debugPod.image | object | `{"registry":"docker.io","repository":"greptime/greptime-tool","tag":"20250213-e64e46c"}` | The debug pod image |
+| debugPod.image | object | `{"registry":"docker.io","repository":"greptime/greptime-tool","tag":"20250317-5281e66"}` | The debug pod image |
 | debugPod.resources | object | `{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | The debug pod resource |
 | dedicatedWAL | object | `{"enabled":false,"raftEngine":{"fs":{"mountPath":"/wal","name":"wal","storageClassName":null,"storageSize":"20Gi"}}}` | Configure to dedicated wal |
 | dedicatedWAL.enabled | bool | `false` | Enable dedicated wal |

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -930,7 +930,7 @@ debugPod:
   image:
     registry: docker.io
     repository: greptime/greptime-tool
-    tag: "20250213-e64e46c"
+    tag: "20250317-5281e66"
 
   # -- The debug pod resource
   resources:


### PR DESCRIPTION
Add some tools to build from this: https://github.com/GreptimeTeam/helm-charts/pull/237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - **Release Version:** Updated the release to version 0.3.4 so that all user‐facing version details remain current. This helps users quickly recognize the most up-to-date release.
  - **Debug Image:** Refreshed the debugging image with an updated build tag, contributing to a more reliable and consistent debugging experience for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->