### PR TITLE
chore: reset default volume size

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.3.5
+version: 0.3.6
 appVersion: 0.13.1
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.1](https://img.shields.io/badge/AppVersion-0.13.1-informational?style=flat-square)
+![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.1](https://img.shields.io/badge/AppVersion-0.13.1-informational?style=flat-square)
 
 ## Source Code
 
@@ -111,7 +111,7 @@ helm uninstall mycluster -n default
 | dashboards.label | string | `"grafana_dashboard"` | The label as defined in the grafana helmchart. https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |
 | dashboards.labelValue | string | `"1"` | The label value as defined in the grafana helmchart. https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |
 | dashboards.namespace | string | `""` | The namespace in which the grafana dashboard configmaps are installed |
-| datanode | object | `{"configData":"","configFile":"","logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"storage":{"annotations":{},"dataHome":"/data/greptimedb","labels":{},"mountPath":"/data/greptimedb","storageClassName":null,"storageRetainPolicy":"Retain","storageSize":"10Gi"}}` | Datanode configure |
+| datanode | object | `{"configData":"","configFile":"","logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"storage":{"annotations":{},"dataHome":"/data/greptimedb","labels":{},"mountPath":"/data/greptimedb","storageClassName":null,"storageRetainPolicy":"Retain","storageSize":"20Gi"}}` | Datanode configure |
 | datanode.configData | string | `""` | Extra raw toml config data of datanode. Skip if the `configFile` is used. |
 | datanode.configFile | string | `""` | Extra toml file of datanode. |
 | datanode.logging | object | `{}` | Logging configuration for datanode, if not set, it will use the global logging configuration. |
@@ -144,7 +144,7 @@ helm uninstall mycluster -n default
 | datanode.storage.mountPath | string | `"/data/greptimedb"` | The data directory of the storage, default is "/data/greptimedb" |
 | datanode.storage.storageClassName | string | `nil` | Storage class for datanode persistent volume |
 | datanode.storage.storageRetainPolicy | string | `"Retain"` | Storage retain policy for datanode persistent volume |
-| datanode.storage.storageSize | string | `"10Gi"` | Storage size for datanode persistent volume |
+| datanode.storage.storageSize | string | `"20Gi"` | Storage size for datanode persistent volume |
 | debugPod.enabled | bool | `false` | Enable debug pod, for more information see: "../../docker/debug-pod/README.md". |
 | debugPod.image | object | `{"registry":"docker.io","repository":"greptime/greptime-tool","tag":"20250317-5281e66"}` | The debug pod image |
 | debugPod.resources | object | `{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | The debug pod resource |

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -537,7 +537,7 @@ datanode:
     # -- Storage class for datanode persistent volume
     storageClassName: null
     # -- Storage size for datanode persistent volume
-    storageSize: 10Gi
+    storageSize: 20Gi
     # -- Storage retain policy for datanode persistent volume
     storageRetainPolicy: Retain
     # -- The dataHome directory, default is "/data/greptimedb/"
@@ -993,9 +993,9 @@ monitoring:
 #     datanodeStorage:
 #       fs:
 #         # -- Storage class for datanode persistent volume
-#         storageClassName: test
+#         storageClassName: null
 #         # -- Storage size for datanode persistent volume
-#         storageSize: 500Gi
+#         storageSize: 50Gi
 #         # -- Storage retain policy for datanode persistent volume
 #         storageRetainPolicy: Retain
 #         # -- The dataHome directory, default is "/data/greptimedb/"

--- a/charts/greptimedb-standalone/Chart.yaml
+++ b/charts/greptimedb-standalone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-standalone
 description: A Helm chart for deploying standalone greptimedb
 type: application
-version: 0.1.45
+version: 0.1.46
 appVersion: 0.13.1
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying standalone greptimedb
 
-![Version: 0.1.45](https://img.shields.io/badge/Version-0.1.45-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.1](https://img.shields.io/badge/AppVersion-0.13.1-informational?style=flat-square)
+![Version: 0.1.46](https://img.shields.io/badge/Version-0.1.46-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.1](https://img.shields.io/badge/AppVersion-0.13.1-informational?style=flat-square)
 
 ## Source Code
 - https://github.com/GreptimeTeam/greptimedb
@@ -85,7 +85,7 @@ helm uninstall greptimedb-standalone -n default
 | persistence.enabled | bool | `true` | Enable persistent disk |
 | persistence.mountPath | string | `"/data/greptimedb"` | Mount path of persistent disk. |
 | persistence.selector | string | `nil` | Selector for persistent disk |
-| persistence.size | string | `"10Gi"` | Size of persistent disk |
+| persistence.size | string | `"20Gi"` | Size of persistent disk |
 | persistence.storageClass | string | `nil` | Storage class name |
 | persistentVolumeClaimRetentionPolicy | object | `{"whenDeleted":"Retain","whenScaled":"Retain"}` | PersistentVolumeClaimRetentionPolicyType is a string enumeration of the policies that will determine, when volumes from the VolumeClaimTemplates will be deleted when the controlling StatefulSet is deleted or scaled down. |
 | podAnnotations | object | `{}` | Extra pod annotations to add |

--- a/charts/greptimedb-standalone/values.yaml
+++ b/charts/greptimedb-standalone/values.yaml
@@ -206,7 +206,7 @@ persistence:
   # -- Enable StatefulSetAutoDeletePVC feature
   enableStatefulSetAutoDeletePVC: false
   # -- Size of persistent disk
-  size: 10Gi
+  size: 20Gi
   # -- Storage class name
   storageClass: null
   # -- Selector for persistent disk


### PR DESCRIPTION
Set the default disk size to 20GB, Some cloud provider, such as Alibaba Cloud, minimum ESSD disk size is 20GB.

![image](https://github.com/user-attachments/assets/01a0fc18-94fc-460e-8070-867cf775c76d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Bumped deployment chart versions to align with the latest release.
	- Increased default storage allocations from 10Gi to 20Gi for both cluster and standalone deployments.
	- Revised monitoring storage settings by reducing allocated capacity and updating the storage class configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->