### PR TITLE
feat!: bump greptimedb-operator version to v0.2.1

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.3.7
+version: 0.3.8
 appVersion: 0.13.2
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.3.7](https://img.shields.io/badge/Version-0.3.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.2](https://img.shields.io/badge/AppVersion-0.13.2-informational?style=flat-square)
+![Version: 0.3.8](https://img.shields.io/badge/Version-0.3.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.2](https://img.shields.io/badge/AppVersion-0.13.2-informational?style=flat-square)
 
 ## Source Code
 
@@ -243,7 +243,7 @@ helm uninstall mycluster -n default
 | image.tag | string | `"v0.13.2"` | The image tag |
 | initializer.registry | string | `"docker.io"` | Initializer image registry |
 | initializer.repository | string | `"greptime/greptimedb-initializer"` | Initializer image repository |
-| initializer.tag | string | `"v0.2.1-alpha.1"` | Initializer image tag |
+| initializer.tag | string | `"v0.2.1"` | Initializer image tag |
 | jaeger-all-in-one | object | `{"enableHttpOpenTelemetryCollector":true,"enableHttpZipkinCollector":true,"enabled":false,"image":{"pullPolicy":"IfNotPresent","repository":"jaegertracing/all-in-one","versionOverride":"latest"},"resources":{},"service":{"annotations":{},"port":16686,"type":"ClusterIP"},"volume":{"className":"","enabled":true,"size":"3Gi"}}` | Deploy jaeger-all-in-one for development purpose. |
 | jaeger-all-in-one.enableHttpOpenTelemetryCollector | bool | `true` | Enable the opentelemetry collector for jaeger-all-in-one and listen on port 4317. |
 | jaeger-all-in-one.enableHttpZipkinCollector | bool | `true` | Enable the zipkin collector for jaeger-all-in-one and listen on port 9411. |

--- a/charts/greptimedb-cluster/templates/secret.yaml
+++ b/charts/greptimedb-cluster/templates/secret.yaml
@@ -20,6 +20,9 @@ stringData:
   {{- if .Values.objectStorage.credentials.secretAccessKey }}
   secret-access-key: {{ .Values.objectStorage.credentials.secretAccessKey }}
   {{- end }}
+  {{- if .Values.objectStorage.credentials.accessKeySecret }}
+  access-key-secret: {{ .Values.objectStorage.credentials.accessKeySecret }}
+  {{- end }}
   {{- if .Values.objectStorage.credentials.accountName }}
   account-name: {{ .Values.objectStorage.credentials.accountName }}
   {{- end }}

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -17,7 +17,7 @@ initializer:
   # -- Initializer image repository
   repository: greptime/greptimedb-initializer
   # -- Initializer image tag
-  tag: v0.2.1-alpha.1
+  tag: v0.2.1
 
 base:
   # -- The pod template for base
@@ -836,9 +836,14 @@ objectStorage:
 #  credentials:
 #    secretName: ""
 
-#    # AWS or AliCloud cloudProvider accessKeyID and secretAccessKey
+#    # AWS or AliCloud cloudProvider accessKeyID
 #    accessKeyId: "you-should-set-the-access-key-id-here"
+
+#    # AWS cloudProvider secretAccessKey
 #    secretAccessKey: "you-should-set-the-secret-access-key-here"
+
+#    # AliCloud cloudProvider secretAccessKey
+#    accessKeySecret: "you-should-set-the-access-key-secret-here"
 
 #    # Azure cloudProvider accountName and accountKey
 #    accountName: "you-should-set-the-account-name-here"

--- a/charts/greptimedb-operator/Chart.yaml
+++ b/charts/greptimedb-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 kubeVersion: ">=1.18.0-0"
 description: The greptimedb-operator Helm chart for Kubernetes.
 name: greptimedb-operator
-appVersion: 0.2.1-alpha.1
-version: 0.2.18
+appVersion: 0.2.1
+version: 0.2.19
 type: application
 home: https://github.com/GreptimeTeam/greptimedb-operator
 sources:

--- a/charts/greptimedb-operator/README.md
+++ b/charts/greptimedb-operator/README.md
@@ -2,7 +2,7 @@
 
 The greptimedb-operator Helm chart for Kubernetes.
 
-![Version: 0.2.18](https://img.shields.io/badge/Version-0.2.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.1-alpha.1](https://img.shields.io/badge/AppVersion-0.2.1--alpha.1-informational?style=flat-square)
+![Version: 0.2.19](https://img.shields.io/badge/Version-0.2.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.1](https://img.shields.io/badge/AppVersion-0.2.1-informational?style=flat-square)
 
 ## Source Code
 
@@ -116,7 +116,7 @@ Kubernetes: `>=1.18.0-0`
 | image.pullSecrets | list | `[]` | The image pull secrets |
 | image.registry | string | `"docker.io"` | The image registry |
 | image.repository | string | `"greptime/greptimedb-operator"` | The image repository |
-| image.tag | string | `"v0.2.1-alpha.1"` | The image tag |
+| image.tag | string | `"v0.2.1"` | The image tag |
 | nameOverride | string | `""` | String to partially override release template name |
 | nodeSelector | object | `{}` | The operator node selector |
 | rbac.create | bool | `true` | Install role based access control |

--- a/charts/greptimedb-operator/templates/clusterrole.yaml
+++ b/charts/greptimedb-operator/templates/clusterrole.yaml
@@ -44,6 +44,7 @@ rules:
       - configmaps
     verbs:
       - create
+      - delete
       - get
       - list
       - patch
@@ -78,6 +79,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - ""
@@ -86,6 +88,7 @@ rules:
     verbs:
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - ""
@@ -155,6 +158,18 @@ rules:
       - monitoring.coreos.com
     resources:
       - podmonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
     verbs:
       - create
       - delete

--- a/charts/greptimedb-operator/templates/crds/crd-greptimedbcluster.yaml
+++ b/charts/greptimedb-operator/templates/crds/crd-greptimedbcluster.yaml
@@ -15355,6 +15355,49 @@ spec:
                   maximum: 65535
                   minimum: 0
                   type: integer
+                ingress:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    ingressClassName:
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    rules:
+                      items:
+                        properties:
+                          backends:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                path:
+                                  type: string
+                                pathType:
+                                  type: string
+                              type: object
+                            type: array
+                          host:
+                            type: string
+                        type: object
+                      type: array
+                    tls:
+                      items:
+                        properties:
+                          hosts:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          secretName:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
                 initializer:
                   properties:
                     image:
@@ -21628,6 +21671,8 @@ spec:
                               properties:
                                 bucket:
                                   type: string
+                                enableVirtualHostStyle:
+                                  type: boolean
                                 endpoint:
                                   type: string
                                 region:
@@ -21868,6 +21913,8 @@ spec:
                       properties:
                         bucket:
                           type: string
+                        enableVirtualHostStyle:
+                          type: boolean
                         endpoint:
                           type: string
                         region:

--- a/charts/greptimedb-operator/templates/crds/crd-greptimedbstandalone.yaml
+++ b/charts/greptimedb-operator/templates/crds/crd-greptimedbstandalone.yaml
@@ -3198,6 +3198,8 @@ spec:
                       properties:
                         bucket:
                           type: string
+                        enableVirtualHostStyle:
+                          type: boolean
                         endpoint:
                           type: string
                         region:

--- a/charts/greptimedb-operator/values.yaml
+++ b/charts/greptimedb-operator/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- The image pull policy for the controller
   imagePullPolicy: IfNotPresent
   # -- The image tag
-  tag: v0.2.1-alpha.1
+  tag: v0.2.1
   # -- The image pull secrets
   pullSecrets: []
 


### PR DESCRIPTION
- Bump operator version to v0.2.1

- Breaking change: 
rename Alicloud `secretAccessKey` to `accessKeySecret` in the greptimedb-cluster object storage configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for detailed ingress configuration in the GreptimeDB cluster, including annotations, ingress class name, labels, rules, and TLS settings.
  - Introduced the ability to enable virtual host style addressing for object storage buckets in both cluster and standalone deployments.

- **Improvements**
  - Expanded operator permissions to manage ingresses, and enhanced permissions for configmaps, pods, secrets, and services.

- **Bug Fixes**
  - Added conditional support for an additional object storage credential field in secret management.

- **Documentation**
  - Updated documentation to reflect new and changed configuration options, including ingress and object storage settings.
  - Updated version numbers and image tags for both cluster and operator charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->