### PR TITLE
feat(greptimedb-operator): add cert-manager configuration to automatically sign admission webhook certificate

### DIFF
--- a/charts/greptimedb-operator/Chart.yaml
+++ b/charts/greptimedb-operator/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.18.0-0"
 description: The greptimedb-operator Helm chart for Kubernetes.
 name: greptimedb-operator
 appVersion: 0.2.2
-version: 0.2.21
+version: 0.2.22
 type: application
 home: https://github.com/GreptimeTeam/greptimedb-operator
 sources:

--- a/charts/greptimedb-operator/README.md
+++ b/charts/greptimedb-operator/README.md
@@ -108,6 +108,7 @@ Kubernetes: `>=1.18.0-0`
 | admissionWebhook.caBundle | string | `""` | A PEM encoded CA bundle which will be used to validate the webhook's server certificate. If certManager.enabled is true, you can get it like this: kubectl get secret webhook-server-tls -n ${namespace} -o jsonpath='{.data.ca\.crt}' |
 | admissionWebhook.certDir | string | `"/etc/webhook-tls"` | The directory that contains the certificate |
 | admissionWebhook.certManager | object | `{"admissionCert":{"duration":""},"enabled":false,"rootCert":{"duration":""}}` | Use certmanager to generate webhook certs |
+| admissionWebhook.certManager.admissionCert | object | `{"duration":""}` | self-signed webhook certificate |
 | admissionWebhook.certManager.rootCert | object | `{"duration":""}` | self-signed root certificate |
 | admissionWebhook.enabled | bool | `false` | Whether to enable the admission webhook |
 | admissionWebhook.failurePolicy | string | `"Fail"` | Valid values: Fail, Ignore, IgnoreOnInstallOnly |

--- a/charts/greptimedb-operator/README.md
+++ b/charts/greptimedb-operator/README.md
@@ -2,7 +2,7 @@
 
 The greptimedb-operator Helm chart for Kubernetes.
 
-![Version: 0.2.21](https://img.shields.io/badge/Version-0.2.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.2](https://img.shields.io/badge/AppVersion-0.2.2-informational?style=flat-square)
+![Version: 0.2.22](https://img.shields.io/badge/Version-0.2.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.2](https://img.shields.io/badge/AppVersion-0.2.2-informational?style=flat-square)
 
 ## Source Code
 
@@ -103,10 +103,12 @@ Kubernetes: `>=1.18.0-0`
 | VolumeMounts | list | `[]` | Volume mounts to add to the pod |
 | Volumes | list | `[]` | Volumes to add to the pod |
 | additionalLabels | object | `{}` | additional labels to add to all resources |
-| admissionWebhook | object | `{"annotations":{},"caBundle":"","certDir":"/etc/webhook-tls","enabled":false,"failurePolicy":"Fail","port":8082}` | The configuration for the admission webhook |
+| admissionWebhook | object | `{"annotations":{},"caBundle":"","certDir":"/etc/webhook-tls","certManager":{"admissionCert":{"duration":""},"enabled":false,"rootCert":{"duration":""}},"enabled":false,"failurePolicy":"Fail","port":8082}` | The configuration for the admission webhook |
 | admissionWebhook.annotations | object | `{}` | Additional annotations to the admission webhooks |
-| admissionWebhook.caBundle | string | `""` | A PEM encoded CA bundle which will be used to validate the webhook's server certificate. |
+| admissionWebhook.caBundle | string | `""` | A PEM encoded CA bundle which will be used to validate the webhook's server certificate. If certManager.enabled is true, you can get it like this: kubectl get secret webhook-server-tls -n ${namespace} -o jsonpath='{.data.ca\.crt}' |
 | admissionWebhook.certDir | string | `"/etc/webhook-tls"` | The directory that contains the certificate |
+| admissionWebhook.certManager | object | `{"admissionCert":{"duration":""},"enabled":false,"rootCert":{"duration":""}}` | Use certmanager to generate webhook certs |
+| admissionWebhook.certManager.rootCert | object | `{"duration":""}` | self-signed root certificate |
 | admissionWebhook.enabled | bool | `false` | Whether to enable the admission webhook |
 | admissionWebhook.failurePolicy | string | `"Fail"` | Valid values: Fail, Ignore, IgnoreOnInstallOnly |
 | admissionWebhook.port | int | `8082` | The port for the admission webhook |

--- a/charts/greptimedb-operator/templates/NOTES.txt
+++ b/charts/greptimedb-operator/templates/NOTES.txt
@@ -7,4 +7,4 @@
 Installed components:
 * greptimedb-operator
 
-The greptimedb-operator is starting, use `kubectl get deployments {{ include "greptimedb-operator.fullname" . }} -n {{ .Release.Namespace }}` to check its status.
+The greptimedb-operator is starting, use `kubectl get deployment {{ include "greptimedb-operator.fullname" . }} -n {{ .Release.Namespace }}` to check its status.

--- a/charts/greptimedb-operator/templates/cert-manager.yaml
+++ b/charts/greptimedb-operator/templates/cert-manager.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.admissionWebhook.certManager.enabled }}
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    {{- include "greptimedb-operator.labels" . | nindent 4 }}
+  name: {{ include "greptimedb-operator.fullname" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "greptimedb-operator.fullname" . }}-root-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-operator.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "greptimedb-operator.fullname" . }}-root-cert
+  duration: {{ .Values.admissionWebhook.certManager.rootCert.duration | default "43800h0m0s" | quote }}
+  issuerRef:
+    name: {{ include "greptimedb-operator.fullname" . }}-selfsigned-issuer
+  commonName: "ca.webhook.greptimedb-operator"
+  isCA: true
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "greptimedb-operator.fullname" . }}-root-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+      {{- include "greptimedb-operator.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ include "greptimedb-operator.fullname" . }}-root-cert
+---
+# generate a server certificate for the apiservices to use
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    {{- include "greptimedb-operator.labels" . | nindent 4 }}
+  name: {{ include "greptimedb-operator.fullname" . }}-webhook-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+    - {{ include "greptimedb-operator.fullname" . }}
+    - {{ include "greptimedb-operator.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "greptimedb-operator.fullname" . }}.{{ .Release.Namespace }}.svc
+  issuerRef:
+    kind: Issuer
+    name: {{ include "greptimedb-operator.fullname" . }}-root-issuer
+  secretName: webhook-server-tls
+  duration: {{ .Values.admissionWebhook.certManager.admissionCert.duration | default "8760h0m0s" | quote }}
+{{- end }}

--- a/charts/greptimedb-operator/values.yaml
+++ b/charts/greptimedb-operator/values.yaml
@@ -96,7 +96,21 @@ admissionWebhook:
   failurePolicy: Fail
 
   # -- A PEM encoded CA bundle which will be used to validate the webhook's server certificate.
+  # If certManager.enabled is true, you can get it like this: kubectl get secret webhook-server-tls -n ${namespace} -o jsonpath='{.data.ca\.crt}'
   caBundle: ""
+
+  # -- Use certmanager to generate webhook certs
+  certManager:
+    enabled: false
+
+    # -- self-signed root certificate
+    rootCert:
+      # default to be 5 year
+      duration: "" # 43800h0m0s
+
+    admissionCert:
+      # default to be 1 year
+      duration: "" # 8760h0m0s
 
 # -- The configuration for the operator API server
 apiServer:

--- a/charts/greptimedb-operator/values.yaml
+++ b/charts/greptimedb-operator/values.yaml
@@ -106,11 +106,12 @@ admissionWebhook:
     # -- self-signed root certificate
     rootCert:
       # default to be 5 year
-      duration: "" # 43800h0m0s
+      duration: ""  # 43800h0m0s
 
+    # -- self-signed webhook certificate
     admissionCert:
       # default to be 1 year
-      duration: "" # 8760h0m0s
+      duration: ""  # 8760h0m0s
 
 # -- The configuration for the operator API server
 apiServer:


### PR DESCRIPTION
When `admissionWebhook.certManager.enabled` is true, Automatically sign webhook certificate.