### PR TITLE
chore: bump greptimedb-operator version to v0.4.2

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.6.13
+version: 0.6.14
 appVersion: 0.16.0
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.6.13](https://img.shields.io/badge/Version-0.6.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.0](https://img.shields.io/badge/AppVersion-0.16.0-informational?style=flat-square)
+![Version: 0.6.14](https://img.shields.io/badge/Version-0.6.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.0](https://img.shields.io/badge/AppVersion-0.16.0-informational?style=flat-square)
 
 ## Source Code
 
@@ -261,7 +261,7 @@ helm uninstall mycluster -n default
 | ingress | object | `{}` | Configure to frontend ingress |
 | initializer.registry | string | `"docker.io"` | Initializer image registry |
 | initializer.repository | string | `"greptime/greptimedb-initializer"` | Initializer image repository |
-| initializer.tag | string | `"v0.4.1"` | Initializer image tag |
+| initializer.tag | string | `"v0.4.2"` | Initializer image tag |
 | jaeger-all-in-one.enableHttpOpenTelemetryCollector | bool | `true` | Enable the opentelemetry collector for jaeger-all-in-one and listen on port 4317. |
 | jaeger-all-in-one.enableHttpZipkinCollector | bool | `true` | Enable the zipkin collector for jaeger-all-in-one and listen on port 9411. |
 | jaeger-all-in-one.enabled | bool | `false` | Enable jaeger-all-in-one deployment. |

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -30,7 +30,7 @@ initializer:
   # -- Initializer image repository
   repository: greptime/greptimedb-initializer
   # -- Initializer image tag
-  tag: v0.4.1
+  tag: v0.4.2
 
 base:
   # -- The pod template for base

--- a/charts/greptimedb-operator/Chart.yaml
+++ b/charts/greptimedb-operator/Chart.yaml
@@ -2,15 +2,14 @@ apiVersion: v2
 kubeVersion: ">=1.18.0-0"
 description: The greptimedb-operator Helm chart for Kubernetes.
 name: greptimedb-operator
-appVersion: 0.4.1
-version: 0.4.0
+appVersion: 0.4.2
+version: 0.4.1
 type: application
 home: https://github.com/GreptimeTeam/greptimedb-operator
 sources:
   - https://github.com/GreptimeTeam/greptimedb-operator
 keywords:
   - operator
-  - database
   - greptimedb
 maintainers:
   - name: daviderli614

--- a/charts/greptimedb-operator/README.md
+++ b/charts/greptimedb-operator/README.md
@@ -2,7 +2,7 @@
 
 The greptimedb-operator Helm chart for Kubernetes.
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.1](https://img.shields.io/badge/AppVersion-0.4.1-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2](https://img.shields.io/badge/AppVersion-0.4.2-informational?style=flat-square)
 
 ## Source Code
 
@@ -128,7 +128,7 @@ Kubernetes: `>=1.18.0-0`
 | image.pullSecrets | list | `[]` | The image pull secrets |
 | image.registry | string | `"docker.io"` | The image registry |
 | image.repository | string | `"greptime/greptimedb-operator"` | The image repository |
-| image.tag | string | `"v0.4.1"` | The image tag |
+| image.tag | string | `"v0.4.2"` | The image tag |
 | nameOverride | string | `""` | String to partially override release template name |
 | nodeSelector | object | `{}` | The operator node selector |
 | rbac.create | bool | `true` | Install role based access control |

--- a/charts/greptimedb-operator/templates/crds/crd-greptimedbcluster.yaml
+++ b/charts/greptimedb-operator/templates/crds/crd-greptimedbcluster.yaml
@@ -1960,6 +1960,10 @@ spec:
                               - name
                             type: object
                           type: array
+                        extraArgs:
+                          items:
+                            type: string
+                          type: array
                         image:
                           type: string
                         imagePullPolicy:
@@ -3434,6 +3438,8 @@ spec:
                             storageSize:
                               pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
                               type: string
+                            useEmptyDir:
+                              type: boolean
                           type: object
                       type: object
                     template:
@@ -5337,6 +5343,10 @@ spec:
                                   - name
                                 type: object
                               type: array
+                            extraArgs:
+                              items:
+                                type: string
+                              type: array
                             image:
                               type: string
                             imagePullPolicy:
@@ -6727,6 +6737,15 @@ spec:
                             type: object
                           type: array
                       type: object
+                    tracing:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          type: string
+                        sampleRatio:
+                          type: string
+                      type: object
                   type: object
                 datanodeGroups:
                   items:
@@ -6813,6 +6832,8 @@ spec:
                               storageSize:
                                 pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
                                 type: string
+                              useEmptyDir:
+                                type: boolean
                             type: object
                         type: object
                       template:
@@ -8716,6 +8737,10 @@ spec:
                                     - name
                                   type: object
                                 type: array
+                              extraArgs:
+                                items:
+                                  type: string
+                                type: array
                               image:
                                 type: string
                               imagePullPolicy:
@@ -10105,6 +10130,15 @@ spec:
                                 - name
                               type: object
                             type: array
+                        type: object
+                      tracing:
+                        properties:
+                          enabled:
+                            type: boolean
+                          endpoint:
+                            type: string
+                          sampleRatio:
+                            type: string
                         type: object
                     type: object
                   type: array
@@ -12063,6 +12097,10 @@ spec:
                                   - name
                                 type: object
                               type: array
+                            extraArgs:
+                              items:
+                                type: string
+                              type: array
                             image:
                               type: string
                             imagePullPolicy:
@@ -13452,6 +13490,15 @@ spec:
                               - name
                             type: object
                           type: array
+                      type: object
+                    tracing:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          type: string
+                        sampleRatio:
+                          type: string
                       type: object
                   type: object
                 frontend:
@@ -15454,6 +15501,10 @@ spec:
                                   - name
                                 type: object
                               type: array
+                            extraArgs:
+                              items:
+                                type: string
+                              type: array
                             image:
                               type: string
                             imagePullPolicy:
@@ -16850,6 +16901,15 @@ spec:
                           type: string
                       required:
                         - secretName
+                      type: object
+                    tracing:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          type: string
+                        sampleRatio:
+                          type: string
                       type: object
                   type: object
                 frontendGroups:
@@ -18853,6 +18913,10 @@ spec:
                                     - name
                                   type: object
                                 type: array
+                              extraArgs:
+                                items:
+                                  type: string
+                                type: array
                               image:
                                 type: string
                               imagePullPolicy:
@@ -20249,6 +20313,15 @@ spec:
                             type: string
                         required:
                           - secretName
+                        type: object
+                      tracing:
+                        properties:
+                          enabled:
+                            type: boolean
+                          endpoint:
+                            type: string
+                          sampleRatio:
+                            type: string
                         type: object
                     type: object
                   type: array
@@ -22356,6 +22429,10 @@ spec:
                                   - name
                                 type: object
                               type: array
+                            extraArgs:
+                              items:
+                                type: string
+                              type: array
                             image:
                               type: string
                             imagePullPolicy:
@@ -23745,6 +23822,15 @@ spec:
                               - name
                             type: object
                           type: array
+                      type: object
+                    tracing:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          type: string
+                        sampleRatio:
+                          type: string
                       type: object
                   type: object
                 monitoring:
@@ -25662,6 +25748,10 @@ spec:
                                       - name
                                     type: object
                                   type: array
+                                extraArgs:
+                                  items:
+                                    type: string
+                                  type: array
                                 image:
                                   type: string
                                 imagePullPolicy:
@@ -27082,6 +27172,8 @@ spec:
                                 storageSize:
                                   pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
                                   type: string
+                                useEmptyDir:
+                                  type: boolean
                               type: object
                           type: object
                         httpPort:
@@ -27168,6 +27260,8 @@ spec:
                                     storageSize:
                                       pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
                                       type: string
+                                    useEmptyDir:
+                                      type: boolean
                                   type: object
                               type: object
                             gcs:
@@ -27295,6 +27389,15 @@ spec:
                           required:
                             - secretName
                           type: object
+                        tracing:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              type: string
+                            sampleRatio:
+                              type: string
+                          type: object
                         version:
                           type: string
                         wal:
@@ -27334,6 +27437,8 @@ spec:
                                     storageSize:
                                       pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
                                       type: string
+                                    useEmptyDir:
+                                      type: boolean
                                   type: object
                               type: object
                           type: object
@@ -27428,6 +27533,8 @@ spec:
                             storageSize:
                               pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
                               type: string
+                            useEmptyDir:
+                              type: boolean
                           type: object
                       type: object
                     gcs:
@@ -27506,6 +27613,15 @@ spec:
                   maximum: 65535
                   minimum: 0
                   type: integer
+                tracing:
+                  properties:
+                    enabled:
+                      type: boolean
+                    endpoint:
+                      type: string
+                    sampleRatio:
+                      type: string
+                  type: object
                 version:
                   type: string
                 wal:
@@ -27545,6 +27661,8 @@ spec:
                             storageSize:
                               pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
                               type: string
+                            useEmptyDir:
+                              type: boolean
                           type: object
                       type: object
                   type: object

--- a/charts/greptimedb-operator/templates/crds/crd-greptimedbstandalone.yaml
+++ b/charts/greptimedb-operator/templates/crds/crd-greptimedbstandalone.yaml
@@ -1948,6 +1948,10 @@ spec:
                               - name
                             type: object
                           type: array
+                        extraArgs:
+                          items:
+                            type: string
+                          type: array
                         image:
                           type: string
                         imagePullPolicy:
@@ -3368,6 +3372,8 @@ spec:
                         storageSize:
                           pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
                           type: string
+                        useEmptyDir:
+                          type: boolean
                       type: object
                   type: object
                 httpPort:
@@ -3454,6 +3460,8 @@ spec:
                             storageSize:
                               pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
                               type: string
+                            useEmptyDir:
+                              type: boolean
                           type: object
                       type: object
                     gcs:
@@ -3581,6 +3589,15 @@ spec:
                   required:
                     - secretName
                   type: object
+                tracing:
+                  properties:
+                    enabled:
+                      type: boolean
+                    endpoint:
+                      type: string
+                    sampleRatio:
+                      type: string
+                  type: object
                 version:
                   type: string
                 wal:
@@ -3620,6 +3637,8 @@ spec:
                             storageSize:
                               pattern: (^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$)
                               type: string
+                            useEmptyDir:
+                              type: boolean
                           type: object
                       type: object
                   type: object

--- a/charts/greptimedb-operator/values.yaml
+++ b/charts/greptimedb-operator/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- The image pull policy for the controller
   imagePullPolicy: IfNotPresent
   # -- The image tag
-  tag: v0.4.1
+  tag: v0.4.2
   # -- The image pull secrets
   pullSecrets: []
 


### PR DESCRIPTION
We can add new feature in the next PR:
- self-monitoring tracing
- extra args
- datanode emptydir storage