### PR TITLE
feat: add new feature for greptimedb-operator v0.4.2 to greptimedb-cluster chart

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.6.17
+version: 0.6.18
 appVersion: 0.16.0
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.6.17](https://img.shields.io/badge/Version-0.6.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.0](https://img.shields.io/badge/AppVersion-0.16.0-informational?style=flat-square)
+![Version: 0.6.18](https://img.shields.io/badge/Version-0.6.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.0](https://img.shields.io/badge/AppVersion-0.16.0-informational?style=flat-square)
 
 ## Source Code
 
@@ -97,14 +97,15 @@ helm uninstall mycluster -n default
 | auth.fileName | string | `"passwd"` | The auth file name, the full path is `${mountPath}/${fileName}` |
 | auth.mountPath | string | `"/etc/greptimedb/auth"` | The auth file path to store the auth info |
 | auth.users | list | `[{"password":"admin","username":"admin"}]` | The users to be created in the auth file |
-| base.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{}},"nodeSelector":{},"securityContext":{},"serviceAccountName":"","terminationGracePeriodSeconds":30,"tolerations":[]}` | The pod template for base |
+| base.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"extraArgs":[],"livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{}},"nodeSelector":{},"securityContext":{},"serviceAccountName":"","terminationGracePeriodSeconds":30,"tolerations":[]}` | The pod template for base |
 | base.podTemplate.affinity | object | `{}` | The pod affinity |
 | base.podTemplate.annotations | object | `{}` | The annotations to be created to the pod. |
 | base.podTemplate.labels | object | `{}` | The labels to be created to the pod. |
-| base.podTemplate.main | object | `{"args":[],"command":[],"env":[],"livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{}}` | The base spec of main container |
+| base.podTemplate.main | object | `{"args":[],"command":[],"env":[],"extraArgs":[],"livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{}}` | The base spec of main container |
 | base.podTemplate.main.args | list | `[]` | The arguments to be passed to the command |
 | base.podTemplate.main.command | list | `[]` | The command to be executed in the container |
 | base.podTemplate.main.env | list | `[]` | The environment variables for the container |
+| base.podTemplate.main.extraArgs | list | `[]` | The ExtraArgs specifies additional command-line arguments for the container entrypoint |
 | base.podTemplate.main.livenessProbe | object | `{}` | The config for liveness probe of the main container |
 | base.podTemplate.main.readinessProbe | object | `{}` | The config for readiness probe of the main container |
 | base.podTemplate.main.resources.limits | object | `{}` | The resources limits for the container |
@@ -129,18 +130,19 @@ helm uninstall mycluster -n default
 | dashboards.label | string | `"grafana_dashboard"` | The label as defined in the grafana helmchart. https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |
 | dashboards.labelValue | string | `"1"` | The label value as defined in the grafana helmchart. https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |
 | dashboards.namespace | string | `""` | The namespace in which the grafana dashboard configmaps are installed |
-| datanode | object | `{"configData":"","configFile":"","enabled":true,"logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"storage":{"annotations":{},"dataHome":"/data/greptimedb","labels":{},"mountPath":"/data/greptimedb","storageClassName":null,"storageRetainPolicy":"Retain","storageSize":"20Gi"}}` | Datanode configure |
+| datanode | object | `{"configData":"","configFile":"","enabled":true,"logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"extraArgs":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"storage":{"annotations":{},"dataHome":"/data/greptimedb","labels":{},"mountPath":"/data/greptimedb","storageClassName":null,"storageRetainPolicy":"Retain","storageSize":"20Gi","useEmptyDir":false}}` | Datanode configure |
 | datanode.configData | string | `""` | Extra raw toml config data of datanode. Skip if the `configFile` is used. |
 | datanode.configFile | string | `""` | Extra toml file of datanode. |
 | datanode.logging | object | `{}` | Logging configuration for datanode, if not set, it will use the global logging configuration. |
-| datanode.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for datanode |
+| datanode.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"extraArgs":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for datanode |
 | datanode.podTemplate.affinity | object | `{}` | The pod affinity |
 | datanode.podTemplate.annotations | object | `{}` | The annotations to be created to the pod. |
 | datanode.podTemplate.labels | object | `{}` | The labels to be created to the pod. |
-| datanode.podTemplate.main | object | `{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]}` | The spec of main container |
+| datanode.podTemplate.main | object | `{"args":[],"command":[],"env":[],"extraArgs":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]}` | The spec of main container |
 | datanode.podTemplate.main.args | list | `[]` | The arguments to be passed to the command |
 | datanode.podTemplate.main.command | list | `[]` | The command to be executed in the container |
 | datanode.podTemplate.main.env | list | `[]` | The environment variables for the container |
+| datanode.podTemplate.main.extraArgs | list | `[]` | The ExtraArgs specifies additional command-line arguments for the container entrypoint |
 | datanode.podTemplate.main.image | string | `""` | The datanode image. |
 | datanode.podTemplate.main.livenessProbe | object | `{}` | The config for liveness probe of the main container |
 | datanode.podTemplate.main.readinessProbe | object | `{}` | The config for readiness probe of the main container |
@@ -163,6 +165,7 @@ helm uninstall mycluster -n default
 | datanode.storage.storageClassName | string | `nil` | Storage class for datanode persistent volume |
 | datanode.storage.storageRetainPolicy | string | `"Retain"` | Storage retain policy for datanode persistent volume |
 | datanode.storage.storageSize | string | `"20Gi"` | Storage size for datanode persistent volume |
+| datanode.storage.useEmptyDir | bool | `false` | The useEmptyDir is a flag to indicate whether to use an empty dir. If true, the PVC will not be created and the whole storage of datanode will be cleaned up when the datanode restarts. |
 | datanodeGroups | list | `[]` | datanode instance groups configure, 'spec.datanode' and 'spec.datanodeGroups' cannot be set at the same time. |
 | debugPod | object | `{"enabled":false,"image":{"registry":"docker.io","repository":"greptime/greptime-tool","tag":"20250606-04e3c7d"},"resources":{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}}` | Configure to the debug pod |
 | debugPod.enabled | bool | `false` | Enable debug pod, for more information see: "../../docker/debug-pod/README.md". |
@@ -176,19 +179,20 @@ helm uninstall mycluster -n default
 | dedicatedWAL.raftEngine.fs.name | string | `"wal"` | The name of the wal |
 | dedicatedWAL.raftEngine.fs.storageClassName | string | `nil` | The storage class name |
 | dedicatedWAL.raftEngine.fs.storageSize | string | `"20Gi"` | The storage size |
-| flownode | object | `{"configData":"","configFile":"","enabled":true,"logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1}` | Flownode configure. |
+| flownode | object | `{"configData":"","configFile":"","enabled":true,"logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"extraArgs":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1}` | Flownode configure. |
 | flownode.configData | string | `""` | Extra raw toml config data of flownode. Skip if the `configFile` is used. |
 | flownode.configFile | string | `""` | Extra toml file of flownode. |
 | flownode.enabled | bool | `true` | Enable flownode |
 | flownode.logging | object | `{}` | Logging configuration for flownode, if not set, it will use the global logging configuration. |
-| flownode.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for frontend |
+| flownode.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"extraArgs":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for frontend |
 | flownode.podTemplate.affinity | object | `{}` | The pod affinity |
 | flownode.podTemplate.annotations | object | `{}` | The annotations to be created to the pod. |
 | flownode.podTemplate.labels | object | `{}` | The labels to be created to the pod. |
-| flownode.podTemplate.main | object | `{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]}` | The spec of main container |
+| flownode.podTemplate.main | object | `{"args":[],"command":[],"env":[],"extraArgs":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]}` | The spec of main container |
 | flownode.podTemplate.main.args | list | `[]` | The arguments to be passed to the command |
 | flownode.podTemplate.main.command | list | `[]` | The command to be executed in the container |
 | flownode.podTemplate.main.env | list | `[]` | The environment variables for the container |
+| flownode.podTemplate.main.extraArgs | list | `[]` | The ExtraArgs specifies additional command-line arguments for the container entrypoint |
 | flownode.podTemplate.main.image | string | `""` | The flownode image. |
 | flownode.podTemplate.main.livenessProbe | object | `{}` | The config for liveness probe of the main container |
 | flownode.podTemplate.main.readinessProbe | object | `{}` | The config for readiness probe of the main container |
@@ -204,18 +208,19 @@ helm uninstall mycluster -n default
 | flownode.podTemplate.tolerations | list | `[]` | The pod tolerations |
 | flownode.podTemplate.volumes | list | `[]` | The pod volumes |
 | flownode.replicas | int | `1` | Flownode replicas |
-| frontend | object | `{"configData":"","configFile":"","enabled":true,"logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"service":{},"tls":{}}` | Frontend configure |
+| frontend | object | `{"configData":"","configFile":"","enabled":true,"logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"extraArgs":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"service":{},"tls":{}}` | Frontend configure |
 | frontend.configData | string | `""` | Extra raw toml config data of frontend. Skip if the `configFile` is used. |
 | frontend.configFile | string | `""` | Extra toml file of frontend. |
 | frontend.logging | object | `{}` | Logging configuration for frontend, if not set, it will use the global logging configuration. |
-| frontend.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for frontend |
+| frontend.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"extraArgs":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for frontend |
 | frontend.podTemplate.affinity | object | `{}` | The pod affinity |
 | frontend.podTemplate.annotations | object | `{}` | The annotations to be created to the pod. |
 | frontend.podTemplate.labels | object | `{}` | The labels to be created to the pod. |
-| frontend.podTemplate.main | object | `{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]}` | The spec of main container |
+| frontend.podTemplate.main | object | `{"args":[],"command":[],"env":[],"extraArgs":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]}` | The spec of main container |
 | frontend.podTemplate.main.args | list | `[]` | The arguments to be passed to the command |
 | frontend.podTemplate.main.command | list | `[]` | The command to be executed in the container |
 | frontend.podTemplate.main.env | list | `[]` | The environment variables for the container |
+| frontend.podTemplate.main.extraArgs | list | `[]` | The ExtraArgs specifies additional command-line arguments for the container entrypoint |
 | frontend.podTemplate.main.image | string | `""` | The frontend image. |
 | frontend.podTemplate.main.livenessProbe | object | `{}` | The config for liveness probe of the main container |
 | frontend.podTemplate.main.readinessProbe | object | `{}` | The config for readiness probe of the main container |
@@ -236,7 +241,7 @@ helm uninstall mycluster -n default
 | frontendGroups | list | `[]` | Frontend instance groups configure |
 | grafana.adminPassword | string | `"gt-operator"` | The default admin password for grafana. |
 | grafana.adminUser | string | `"admin"` | The default admin username for grafana. |
-| grafana.datasources | object | `{"datasources.yaml":{"datasources":[{"access":"proxy","isDefault":true,"name":"metrics","type":"prometheus","url":"http://mycluster-monitor-standalone.default.svc.cluster.local:4000/v1/prometheus"},{"access":"proxy","database":"public","name":"logs","type":"mysql","url":"mycluster-monitor-standalone.default.svc.cluster.local:4002"},{"access":"proxy","database":"information_schema","name":"information_schema","type":"mysql","url":"mycluster-frontend.default.svc.cluster.local:4002"}]}}` | The grafana datasources. |
+| grafana.datasources | object | `{"datasources.yaml":{"datasources":[{"access":"proxy","isDefault":true,"name":"metrics","type":"prometheus","url":"http://mycluster-monitor-standalone.default.svc.cluster.local:4000/v1/prometheus"},{"access":"proxy","isDefault":true,"name":"traces","type":"jaeger","url":"http://mycluster-monitor-standalone.default.svc.cluster.local:4000/v1/jaeger"},{"access":"proxy","database":"public","name":"logs","type":"mysql","url":"mycluster-monitor-standalone.default.svc.cluster.local:4002"},{"access":"proxy","database":"information_schema","name":"information_schema","type":"mysql","url":"mycluster-frontend.default.svc.cluster.local:4002"}]}}` | The grafana datasources. |
 | grafana.enabled | bool | `false` | Enable grafana deployment. It needs to enable monitoring `monitoring.enabled: true` first. |
 | grafana.image | object | `{"registry":"docker.io","repository":"grafana/grafana","tag":"11.6.0"}` | The grafana image. |
 | grafana.image.registry | string | `"docker.io"` | The grafana image registry. |
@@ -249,9 +254,10 @@ helm uninstall mycluster -n default
 | grafana.persistence.enabled | bool | `true` | Whether to enable the persistence for grafana. |
 | grafana.persistence.size | string | `"10Gi"` | The storage size for the grafana persistence. |
 | grafana.persistence.storageClassName | string | `nil` | The storageClassName for the grafana persistence. |
-| grafana.service | object | `{"annotations":{},"enabled":true,"type":"ClusterIP"}` | The grafana service configuration. |
+| grafana.service | object | `{"annotations":{},"enabled":true,"port":80,"type":"ClusterIP"}` | The grafana service configuration. |
 | grafana.service.annotations | object | `{}` | The annotations for the grafana service. |
 | grafana.service.enabled | bool | `true` | Whether to create the service for grafana. |
+| grafana.service.port | int | `80` | The grafana service port. |
 | grafana.service.type | string | `"ClusterIP"` | The type of the service. |
 | grafana.sidecar | object | `{"dashboards":{"enabled":true,"provider":{"allowUiUpdates":true},"searchNamespace":"ALL"}}` | The grafana sidecar settings to import dashboards |
 | greptimedb-enterprise-dashboard.affinity | object | `{}` |  |
@@ -356,7 +362,7 @@ helm uninstall mycluster -n default
 | logging.logsDir | string | `"/data/greptimedb/logs"` | The logs directory for greptimedb |
 | logging.onlyLogToStdout | bool | `false` | Whether to log to stdout only |
 | logging.persistentWithData | bool | `false` | indicates whether to persist the log with the datanode data storage. It **ONLY** works for the datanode component. |
-| meta | object | `{"backendStorage":{"etcd":{},"mysql":{},"postgresql":{}},"configData":"","configFile":"","enableRegionFailover":false,"etcdEndpoints":"etcd.etcd-cluster.svc.cluster.local:2379","logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"storeKeyPrefix":""}` | Meta configure |
+| meta | object | `{"backendStorage":{"etcd":{},"mysql":{},"postgresql":{}},"configData":"","configFile":"","enableRegionFailover":false,"etcdEndpoints":"etcd.etcd-cluster.svc.cluster.local:2379","logging":{},"podTemplate":{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"extraArgs":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]},"replicas":1,"storeKeyPrefix":""}` | Meta configure |
 | meta.backendStorage | object | `{"etcd":{},"mysql":{},"postgresql":{}}` | Meta Backend storage configuration |
 | meta.backendStorage.etcd | object | `{}` | Etcd backend storage configuration |
 | meta.backendStorage.mysql | object | `{}` | MySQL backend storage configuration |
@@ -366,14 +372,15 @@ helm uninstall mycluster -n default
 | meta.enableRegionFailover | bool | `false` | Whether to enable region failover |
 | meta.etcdEndpoints | string | `"etcd.etcd-cluster.svc.cluster.local:2379"` | Deprecated: Meta etcd endpoints, use `backendStorage.etcd.etcdEndpoints` instead |
 | meta.logging | object | `{}` | Logging configuration for meta, if not set, it will use the global logging configuration. |
-| meta.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for meta |
+| meta.podTemplate | object | `{"affinity":{},"annotations":{},"labels":{},"main":{"args":[],"command":[],"env":[],"extraArgs":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]},"nodeSelector":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":false},"tolerations":[],"volumes":[]}` | The pod template for meta |
 | meta.podTemplate.affinity | object | `{}` | The pod affinity |
 | meta.podTemplate.annotations | object | `{}` | The annotations to be created to the pod. |
 | meta.podTemplate.labels | object | `{}` | The labels to be created to the pod. |
-| meta.podTemplate.main | object | `{"args":[],"command":[],"env":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]}` | The spec of main container |
+| meta.podTemplate.main | object | `{"args":[],"command":[],"env":[],"extraArgs":[],"image":"","livenessProbe":{},"readinessProbe":{},"resources":{"limits":{},"requests":{}},"securityContext":{},"startupProbe":{},"volumeMounts":[]}` | The spec of main container |
 | meta.podTemplate.main.args | list | `[]` | The arguments to be passed to the command |
 | meta.podTemplate.main.command | list | `[]` | The command to be executed in the container |
 | meta.podTemplate.main.env | list | `[]` | The environment variables for the container |
+| meta.podTemplate.main.extraArgs | list | `[]` | The ExtraArgs specifies additional command-line arguments for the container entrypoint |
 | meta.podTemplate.main.image | string | `""` | The meta image. |
 | meta.podTemplate.main.livenessProbe | object | `{}` | The config for liveness probe of the main container |
 | meta.podTemplate.main.readinessProbe | object | `{}` | The config for readiness probe of the main container |

--- a/charts/greptimedb-cluster/dashboards/greptimedb-cluster-traces.json
+++ b/charts/greptimedb-cluster/dashboards/greptimedb-cluster-traces.json
@@ -1,0 +1,107 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "jaeger",
+        "uid": "PB5AC69FC467C01F3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "jaeger",
+            "uid": "PB5AC69FC467C01F3"
+          },
+          "queryType": "search",
+          "refId": "A",
+          "service": "greptime-datanode"
+        }
+      ],
+      "title": "Traces",
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "GreptimeDB Traces",
+  "uid": "eevrfwva1preoc",
+  "version": 4
+}

--- a/charts/greptimedb-cluster/templates/cluster.yaml
+++ b/charts/greptimedb-cluster/templates/cluster.yaml
@@ -19,6 +19,9 @@ spec:
       {{- if .Values.base.podTemplate.main.args }}
       args: {{ .Values.base.podTemplate.main.args | toYaml | nindent 8 }}
       {{- end }}
+      {{- if .Values.base.podTemplate.main.extraArgs }}
+      extraArgs: {{ .Values.base.podTemplate.main.extraArgs | toYaml | nindent 8 }}
+      {{- end }}
       {{- if .Values.base.podTemplate.main.env }}
       env: {{- toYaml .Values.base.podTemplate.main.env | nindent 8 }}
       {{- end }}
@@ -93,6 +96,9 @@ spec:
         {{- end }}
         {{- if .Values.frontend.podTemplate.main.args }}
         args: {{ .Values.frontend.podTemplate.main.args | toYaml | nindent 8 }}
+        {{- end }}
+        {{- if .Values.frontend.podTemplate.main.extraArgs }}
+        extraArgs: {{ .Values.frontend.podTemplate.main.extraArgs | toYaml | nindent 8 }}
         {{- end }}
         {{- if or .Values.auth.enabled .Values.frontend.podTemplate.main.env }}
         env:
@@ -283,6 +289,9 @@ spec:
         {{- if .Values.meta.podTemplate.main.args }}
         args: {{ .Values.meta.podTemplate.main.args | toYaml | nindent 8 }}
         {{- end }}
+        {{- if .Values.meta.podTemplate.main.extraArgs }}
+        extraArgs: {{ .Values.meta.podTemplate.main.extraArgs | toYaml | nindent 8 }}
+        {{- end }}
         {{- if .Values.meta.podTemplate.main.env }}
         env: {{- toYaml .Values.meta.podTemplate.main.env | nindent 8 }}
         {{- end }}
@@ -352,6 +361,9 @@ spec:
         {{- end }}
         {{- if .Values.datanode.podTemplate.main.args }}
         args: {{ .Values.datanode.podTemplate.main.args | toYaml | nindent 8 }}
+        {{- end }}
+        {{- if .Values.datanode.podTemplate.main.extraArgs }}
+        extraArgs: {{ .Values.datanode.podTemplate.main.extraArgs | toYaml | nindent 8 }}
         {{- end }}
         {{- if .Values.datanode.podTemplate.main.env }}
         env: {{- toYaml .Values.datanode.podTemplate.main.env | nindent 8 }}
@@ -435,6 +447,7 @@ spec:
         {{- if .Values.datanode.storage.annotations }}
         annotations: {{ .Values.datanode.storage.annotations | toYaml | nindent 10 }}
         {{- end }}
+        useEmptyDir: {{ .Values.datanode.storage.useEmptyDir }}
   {{- end }}
   {{- if .Values.flownode.enabled }}
   flownode:
@@ -457,6 +470,9 @@ spec:
         {{- end }}
         {{- if .Values.flownode.podTemplate.main.args }}
         args: {{ .Values.flownode.podTemplate.main.args | toYaml | nindent 8 }}
+        {{- end }}
+        {{- if .Values.flownode.podTemplate.main.extraArgs }}
+        extraArgs: {{ .Values.flownode.podTemplate.main.extraArgs | toYaml | nindent 8 }}
         {{- end }}
         {{- if or .Values.auth.enabled .Values.flownode.podTemplate.main.env }}
         env:

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -57,6 +57,9 @@ base:
       # -- The arguments to be passed to the command
       args: []
 
+      # -- The ExtraArgs specifies additional command-line arguments for the container entrypoint
+      extraArgs: []
+
       # -- The config for startup probe of the main container
       startupProbe: {}
 #        httpGet:
@@ -170,6 +173,9 @@ frontend:
 
       # -- The arguments to be passed to the command
       args: []
+
+      # -- The ExtraArgs specifies additional command-line arguments for the container entrypoint
+      extraArgs: []
 
       # -- The pod volumeMounts
       volumeMounts: []
@@ -320,6 +326,9 @@ meta:
 
       # -- The arguments to be passed to the command
       args: []
+
+      # -- The ExtraArgs specifies additional command-line arguments for the container entrypoint
+      extraArgs: []
 
       # -- The pod volumeMounts
       volumeMounts: []
@@ -529,6 +538,9 @@ datanode:
       # -- The arguments to be passed to the command
       args: []
 
+      # -- The ExtraArgs specifies additional command-line arguments for the container entrypoint
+      extraArgs: []
+
       # -- The pod volumeMounts
       volumeMounts: []
       # -- The config for startup probe of the main container
@@ -628,6 +640,8 @@ datanode:
     labels: {}
     # -- The annotations for the PVC that will be created
     annotations: {}
+    # -- The useEmptyDir is a flag to indicate whether to use an empty dir. If true, the PVC will not be created and the whole storage of datanode will be cleaned up when the datanode restarts.
+    useEmptyDir: false
 
   # -- Logging configuration for datanode, if not set, it will use the global logging configuration.
   logging: {}
@@ -709,6 +723,9 @@ flownode:
 
       # -- The arguments to be passed to the command
       args: []
+
+      # -- The ExtraArgs specifies additional command-line arguments for the container entrypoint
+      extraArgs: []
 
       # -- The pod volumeMounts
       volumeMounts: []
@@ -1339,6 +1356,13 @@ grafana:
           access: proxy
           isDefault: true
 
+        # Query the cluster traces.
+        - name: traces
+          type: jaeger
+          url: http://mycluster-monitor-standalone.default.svc.cluster.local:4000/v1/jaeger
+          access: proxy
+          isDefault: true
+
         # Query the cluster logs and slow queries.
         - name: logs
           type: mysql
@@ -1374,6 +1398,8 @@ grafana:
   service:
     # -- Whether to create the service for grafana.
     enabled: true
+    # -- The grafana service port.
+    port: 80
     # -- The type of the service.
     type: ClusterIP
     # -- The annotations for the grafana service.


### PR DESCRIPTION
1. Add extraArgs related to: https://github.com/GreptimeTeam/greptimedb-operator/pull/309

2. Add `useEmptyDir` to datanode filestorage , relate to: https://github.com/GreptimeTeam/greptimedb-operator/pull/318

example: 
```
apiVersion: greptime.io/v1alpha1
kind: GreptimeDBCluster
metadata:
  name: greptimedb
  namespace: default
spec:
  initializer:
    image: greptime/greptimedb-initializer:latest
  base:
    main:
      image: greptime/greptimedb:latest
  frontend:
    replicas: 1
  meta:
    replicas: 1
    backendStorage:
      etcd:
        endpoints:
          - "etcd.etcd-cluster.svc.cluster.local:2379"
  datanode:
    replicas: 3
    storage:
      fs:
        useEmptyDir: true
        storageSize: 10Gi
```

3. Add self-monitoring traces dashboard and datasource to Grafana when monitoring is enabled.:

<img width="1844" height="532" alt="image" src="https://github.com/user-attachments/assets/7a57ed8d-a25f-4152-b842-8a0bbdf0cb72" />
