### PR TITLE
fix: release charts to acr

### DIFF
--- a/charts/greptimedb-cluster/Chart.lock
+++ b/charts/greptimedb-cluster/Chart.lock
@@ -6,10 +6,10 @@ dependencies:
   repository: https://raw.githubusercontent.com/hansehe/jaeger-all-in-one/master/helm/charts
   version: 0.1.12
 - name: greptimedb-remote-compaction
-  repository: https://greptimeteam.github.io/helm-charts/
+  repository: https://greptimeteam.github.io/helm-charts
   version: 0.1.1
 - name: greptimedb-enterprise-dashboard
-  repository: https://greptimeteam.github.io/helm-charts/
+  repository: https://greptimeteam.github.io/helm-charts
   version: 0.1.0
 digest: sha256:dd5db09b565bc2e3b0d9c38823c97c1efd4db867c772dd3c2192ec8378fafaea
 generated: "2025-08-28T14:32:03.449556-07:00"

--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -30,9 +30,9 @@ dependencies:
     condition: jaeger-all-in-one.enabled
   - name: greptimedb-remote-compaction
     version: 0.1.1
-    repository: https://greptimeteam.github.io/helm-charts/
+    repository: https://greptimeteam.github.io/helm-charts
     condition: greptimedb-remote-compaction.enabled
   - name: greptimedb-enterprise-dashboard
     version: 0.1.0
-    repository: https://greptimeteam.github.io/helm-charts/
+    repository: https://greptimeteam.github.io/helm-charts
     condition: greptimedb-enterprise-dashboard.enabled


### PR DESCRIPTION
Fixed to: https://github.com/GreptimeTeam/helm-charts/actions/runs/17421944874

<img width="2018" height="306" alt="image" src="https://github.com/user-attachments/assets/73a7b8a4-3500-4f61-b528-9d52fd2a8b57" />
