### PR TITLE
feat: add license secret

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.6.29
+version: 0.6.30
 appVersion: 0.17.0
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.6.29](https://img.shields.io/badge/Version-0.6.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.0](https://img.shields.io/badge/AppVersion-0.17.0-informational?style=flat-square)
+![Version: 0.6.30](https://img.shields.io/badge/Version-0.6.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.0](https://img.shields.io/badge/AppVersion-0.17.0-informational?style=flat-square)
 
 ## Source Code
 
@@ -360,6 +360,12 @@ helm uninstall mycluster -n default
 | jaeger-all-in-one.volume.className | string | `""` | The storageclass for the jaeger-all-in-one. |
 | jaeger-all-in-one.volume.enabled | bool | `true` | Whether to enable the persistence for jaeger-all-in-one. |
 | jaeger-all-in-one.volume.size | string | `"3Gi"` | The storage size for the jaeger-all-in-one. |
+| license.data | string | `""` | The license data. You can use `--set-file license.data=./license.txt` to set the license data. |
+| license.enabled | bool | `false` | Enable enterprise features. |
+| license.existingSecretName | string | `""` | The existing secret name to get the license. |
+| license.mountFileName | string | `"current"` | The license file name. |
+| license.mountPath | string | `"/etc/greptimedb/license"` | The license file path to store the license info. |
+| license.secretName | string | `""` | The secret name to store the license. If not set, it will use the ${release-name}-license. |
 | logging | object | `{"filters":[],"format":"text","level":"info","logsDir":"/data/greptimedb/logs","onlyLogToStdout":false,"persistentWithData":false}` | Global logging configuration |
 | logging.filters | list | `[]` | The log filters, use the syntax of `target[span\{field=value\}]=level` to filter the logs. |
 | logging.format | string | `"text"` | The log format for greptimedb, only support "json" and "text" |

--- a/charts/greptimedb-cluster/templates/cluster.yaml
+++ b/charts/greptimedb-cluster/templates/cluster.yaml
@@ -292,14 +292,29 @@ spec:
         {{- if .Values.meta.podTemplate.main.args }}
         args: {{ .Values.meta.podTemplate.main.args | toYaml | nindent 8 }}
         {{- end }}
+        {{- if or .Values.license.enabled .Values.meta.podTemplate.main.extraArgs }}
+        extraArgs:
+        {{- if .Values.license.enabled }}
+        - "--license-file"
+        - {{ .Values.license.mountPath }}/{{ .Values.license.mountFileName }}
+        {{- end }}
         {{- if .Values.meta.podTemplate.main.extraArgs }}
-        extraArgs: {{ .Values.meta.podTemplate.main.extraArgs | toYaml | nindent 8 }}
+        {{- toYaml .Values.meta.podTemplate.main.extraArgs | nindent 8 }}
+        {{- end }}
         {{- end }}
         {{- if .Values.meta.podTemplate.main.env }}
         env: {{- toYaml .Values.meta.podTemplate.main.env | nindent 8 }}
         {{- end }}
+        {{- if or .Values.license.enabled .Values.meta.podTemplate.main.volumeMounts }}
+        volumeMounts:
         {{- if .Values.meta.podTemplate.main.volumeMounts }}
-        volumeMounts: {{- toYaml .Values.meta.podTemplate.main.volumeMounts | nindent 8 }}
+        {{- toYaml .Values.meta.podTemplate.main.volumeMounts | nindent 8 }}
+        {{- end }}
+        {{- if .Values.license.enabled }}
+        - name: license-secret
+          mountPath: {{ .Values.license.mountPath }}
+          readOnly: true
+        {{- end }}
         {{- end }}
         resources:
           requests: {{ .Values.meta.podTemplate.main.resources.requests | toYaml | nindent 12 }}
@@ -334,8 +349,20 @@ spec:
       {{- if .Values.meta.podTemplate.nodeSelector }}
       nodeSelector: {{ .Values.meta.podTemplate.nodeSelector | toYaml | nindent 8 }}
       {{- end }}
-      {{- if .Values.meta.podTemplate.volumes}}
-      volumes: {{ .Values.meta.podTemplate.volumes | toYaml | nindent 8 }}
+      {{- if or .Values.license.enabled .Values.meta.podTemplate.volumes }}
+      volumes:
+      {{- if .Values.meta.podTemplate.volumes }}
+      {{- toYaml .Values.meta.podTemplate.volumes | nindent 6 }}
+      {{- end }}
+      {{- if .Values.license.enabled }}
+      - name: license-secret
+        secret:
+          {{- if .Values.license.existingSecretName }}
+          secretName: {{ .Values.license.existingSecretName }}
+          {{- else }}
+          secretName: {{ default (printf "%s-license" .Release.Name) .Values.license.secretName }}
+          {{- end }}
+      {{- end }}
       {{- end }}
       {{- if .Values.meta.podTemplate.securityContext }}
       securityContext: {{ .Values.meta.podTemplate.securityContext | toYaml | nindent 8 }}

--- a/charts/greptimedb-cluster/templates/license-secret.yaml
+++ b/charts/greptimedb-cluster/templates/license-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.license.enabled (not .Values.license.existingSecretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ default (printf "%s-license" .Release.Name) .Values.license.secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "greptimedb-cluster.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.license.mountFileName }}: |-
+    {{- .Values.license.data | nindent 4 }}
+{{- end }}

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -1308,6 +1308,21 @@ slowQuery:
   # -- The TTL of slow query system table.
   ttl: "30d"
 
+## -- The license configuration for enterprise features.
+license:
+  # -- Enable enterprise features.
+  enabled: false
+  # -- The secret name to store the license. If not set, it will use the ${release-name}-license.
+  secretName: ""
+  # -- The existing secret name to get the license.
+  existingSecretName: ""
+  # -- The license file path to store the license info.
+  mountPath: "/etc/greptimedb/license"
+  # -- The license file name.
+  mountFileName: "current"
+  # -- The license data. You can use `--set-file license.data=./license.txt` to set the license data.
+  data: ""
+
 # -- Deploy grafana dashboards for the grafana dashboard sidecar. https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards
 dashboards:
   # -- Enable the grafana dashboards sidecar.


### PR DESCRIPTION
## What's changed

Add `license` field to inject license for enterprise version, for example:

```
helm upgrade --install mycluster ./charts/greptimedb-cluster \
  --values values.yaml \
  --set license.enabled=true \
  --set-file license.data=license.json
```