### PR TITLE
fix(greptimedb-standalone): add emptyDir volume when persistence is disabled

### DIFF
--- a/charts/greptimedb-standalone/Chart.yaml
+++ b/charts/greptimedb-standalone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-standalone
 description: A Helm chart for deploying standalone greptimedb
 type: application
-version: 0.2.15
+version: 0.2.16
 appVersion: 0.17.2
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-standalone/README.md
+++ b/charts/greptimedb-standalone/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying standalone greptimedb
 
-![Version: 0.2.15](https://img.shields.io/badge/Version-0.2.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.2](https://img.shields.io/badge/AppVersion-0.17.2-informational?style=flat-square)
+![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.2](https://img.shields.io/badge/AppVersion-0.17.2-informational?style=flat-square)
 
 ## Source Code
 - https://github.com/GreptimeTeam/greptimedb

--- a/charts/greptimedb-standalone/templates/statefulset.yaml
+++ b/charts/greptimedb-standalone/templates/statefulset.yaml
@@ -147,6 +147,10 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
+        {{- if not .Values.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
         {{- if .Values.configToml }}
         - name: config
           configMap:


### PR DESCRIPTION
**Problem**
When deploying the greptimedb-standalone chart with persistence.enabled=false, the deployment fails with an error indicating that the data volume does not exist.

**Root cause**
The data volume mount is always defined in the container spec (line 130-131), but the corresponding volume is only created through volumeClaimTemplates when persistence.enabled=true. There was no fallback volume definition for the disabled persistence case.

**Solution**
Added a conditional emptyDir volume for data when persistence.enabled=false in the volumes section of the StatefulSet template.


**Version update:**

* Bumped the chart version from `0.2.15` to `0.2.16` in both `Chart.yaml` and the version badge in `README.md` to reflect the new release. [[1]](diffhunk://#diff-96764bfd100e9337ea3d2b5524d92a8f259fcac41f9c87ebe34a3b38361f3660L5-R5) [[2]](diffhunk://#diff-8a21a682c17c72885afa0e64c167c4c9149fb124a3b5b4dbba785f7220b77776L5-R5)

Helm chart logic improvement:

* Updated `statefulset.yaml` to add an `emptyDir` volume for `data` when persistence is disabled, ensuring the pod can run without persistent storage.