### PR TITLE
feat: update greptimedb-operator v0.6.1

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.8.30
+version: 0.8.31
 appVersion: 1.2.0-beta.1
 home: https://github.com/GreptimeTeam/greptimedb
 sources:

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.8.30](https://img.shields.io/badge/Version-0.8.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0-beta.1](https://img.shields.io/badge/AppVersion-1.2.0--beta.1-informational?style=flat-square)
+![Version: 0.8.31](https://img.shields.io/badge/Version-0.8.31-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0-beta.1](https://img.shields.io/badge/AppVersion-1.2.0--beta.1-informational?style=flat-square)
 
 ## Source Code
 
@@ -365,10 +365,9 @@ helm uninstall mycluster -n default
 | image.registry | string | `"docker.io"` | The image registry |
 | image.repository | string | `"greptime/greptimedb"` | The image repository |
 | image.tag | string | `"v1.2.0-beta.1"` | The image tag |
-| ingress | object | `{}` | Configure to frontend ingress |
 | initializer.registry | string | `"docker.io"` | Initializer image registry |
 | initializer.repository | string | `"greptime/greptimedb-initializer"` | Initializer image repository |
-| initializer.tag | string | `"v0.6.0"` | Initializer image tag |
+| initializer.tag | string | `"v0.6.1"` | Initializer image tag |
 | jaeger-all-in-one.enableHttpOpenTelemetryCollector | bool | `true` | Enable the opentelemetry collector for jaeger-all-in-one and listen on port 4317. |
 | jaeger-all-in-one.enableHttpZipkinCollector | bool | `true` | Enable the zipkin collector for jaeger-all-in-one and listen on port 9411. |
 | jaeger-all-in-one.enabled | bool | `false` | Enable jaeger-all-in-one deployment. |

--- a/charts/greptimedb-cluster/templates/cluster.yaml
+++ b/charts/greptimedb-cluster/templates/cluster.yaml
@@ -748,25 +748,6 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
-  {{- $ingress := .Values.ingress }}
-  {{- if $ingress }}
-  ingress:
-    {{- if $ingress.annotations }}
-    annotations: {{- toYaml $ingress.annotations | nindent 6 }}
-    {{- end }}
-    {{- if $ingress.labels }}
-    labels: {{- toYaml $ingress.labels | nindent 6 }}
-    {{- end }}
-    {{- if $ingress.ingressClassName }}
-    ingressClassName: {{ $ingress.ingressClassName }}
-    {{- end }}
-    {{- if $ingress.rules }}
-    rules: {{- toYaml $ingress.rules | nindent 6 }}
-    {{- end }}
-    {{- if $ingress.tls }}
-    tls: {{- toYaml $ingress.tls | nindent 6 }}
-    {{- end }}
-  {{- end }}
   {{- if .Values.logging}}
   logging:
     {{- if .Values.logging.level }}

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -33,7 +33,7 @@ initializer:
   # -- Initializer image repository
   repository: greptime/greptimedb-initializer
   # -- Initializer image tag
-  tag: v0.6.0
+  tag: v0.6.1
 
 base:
   # -- The pod template for base
@@ -1195,39 +1195,6 @@ dedicatedWAL:
       storageSize: 20Gi
       # -- The mount path
       mountPath: /wal
-
-# -- Configure to frontend ingress
-ingress: {}
- # -- Ingress annotations to apply to the ingress resource
- # annotations: {}
- #   example: frontend-ingress
-
- # -- Labels to apply to the ingress resource
- # labels: {}
- #   example: frontend-ingress
-
- # -- Specify the IngressClassName to use for the ingress
- # ingressClassName: nginx
-
- # -- The rules for routing traffic to the frontend service
- # rules:
- #   - host: ingress.example.com
- #     backends:
- #       - path: /
- #         pathType: Prefix  # Support to 'Prefix', 'ImplementationSpecific', 'Exact'.
-
- #       - name: read        # Specify the read frontend name if it exists.
- #         path: /
- #         pathType: Prefix
- #       - name: write       # Specify the write frontend name if it exists.
- #         path: /v1/sql
- #         pathType: Prefix
-
- # -- TLS configuration for securing the ingress traffic
- # tls:
- #   - secretName: frontend-ingress-tls
- #     hosts:
- #       - ingress.example.com
 
 # -- The static auth for greptimedb, only support one user now(https://docs.greptime.com/user-guide/deployments-administration/authentication/static).
 auth:

--- a/charts/greptimedb-operator/Chart.yaml
+++ b/charts/greptimedb-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 kubeVersion: ">=1.18.0-0"
 description: The greptimedb-operator Helm chart for Kubernetes.
 name: greptimedb-operator
-version: 0.6.1
-appVersion: 0.6.0
+version: 0.6.2
+appVersion: 0.6.1
 type: application
 home: https://github.com/GreptimeTeam/greptimedb-operator
 sources:

--- a/charts/greptimedb-operator/README.md
+++ b/charts/greptimedb-operator/README.md
@@ -2,7 +2,7 @@
 
 The greptimedb-operator Helm chart for Kubernetes.
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.1](https://img.shields.io/badge/AppVersion-0.6.1-informational?style=flat-square)
 
 ## Source Code
 
@@ -127,7 +127,7 @@ Kubernetes: `>=1.18.0-0`
 | image.pullSecrets | list | `[]` | The image pull secrets |
 | image.registry | string | `"docker.io"` | The image registry |
 | image.repository | string | `"greptime/greptimedb-operator"` | The image repository |
-| image.tag | string | `"v0.6.0"` | The image tag |
+| image.tag | string | `"v0.6.1"` | The image tag |
 | leaderElection | object | `{"enabled":true,"leaseDuration":"15s","renewDeadline":"10s","retryPeriod":"2s"}` | Enable leader election for greptimedb operator. |
 | leaderElection.leaseDuration | string | `"15s"` | LeaseDuration is the duration that non-leader candidates will wait to force acquire leadership. |
 | leaderElection.renewDeadline | string | `"10s"` | RenewDeadline is the duration that the acting controlplane will retry refreshing leadership before giving up. |

--- a/charts/greptimedb-operator/templates/clusterrole.yaml
+++ b/charts/greptimedb-operator/templates/clusterrole.yaml
@@ -166,16 +166,4 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
 {{- end }}

--- a/charts/greptimedb-operator/templates/crds/crd-greptimedbcluster.yaml
+++ b/charts/greptimedb-operator/templates/crds/crd-greptimedbcluster.yaml
@@ -13629,6 +13629,24 @@ spec:
                   type: object
                 frontend:
                   properties:
+                    auditLog:
+                      properties:
+                        classes:
+                          type: string
+                        commands:
+                          type: string
+                        dir:
+                          type: string
+                        enabled:
+                          type: boolean
+                        maxLogFiles:
+                          format: int32
+                          type: integer
+                        objectTypes:
+                          type: string
+                        sources:
+                          type: string
+                      type: object
                     config:
                       type: string
                     enableObjectStorage:
@@ -13714,6 +13732,31 @@ spec:
                           type: object
                         loadBalancerClass:
                           type: string
+                        ports:
+                          items:
+                            properties:
+                              appProtocol:
+                                type: string
+                              name:
+                                type: string
+                              nodePort:
+                                format: int32
+                                type: integer
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                type: string
+                              targetPort:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            required:
+                              - port
+                            type: object
+                          type: array
                         type:
                           type: string
                       type: object
@@ -17077,6 +17120,24 @@ spec:
                 frontendGroups:
                   items:
                     properties:
+                      auditLog:
+                        properties:
+                          classes:
+                            type: string
+                          commands:
+                            type: string
+                          dir:
+                            type: string
+                          enabled:
+                            type: boolean
+                          maxLogFiles:
+                            format: int32
+                            type: integer
+                          objectTypes:
+                            type: string
+                          sources:
+                            type: string
+                        type: object
                       config:
                         type: string
                       enableObjectStorage:
@@ -17162,6 +17223,31 @@ spec:
                             type: object
                           loadBalancerClass:
                             type: string
+                          ports:
+                            items:
+                              properties:
+                                appProtocol:
+                                  type: string
+                                name:
+                                  type: string
+                                nodePort:
+                                  format: int32
+                                  type: integer
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            type: array
                           type:
                             type: string
                         type: object
@@ -20528,49 +20614,6 @@ spec:
                   maximum: 65535
                   minimum: 0
                   type: integer
-                ingress:
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    ingressClassName:
-                      type: string
-                    labels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    rules:
-                      items:
-                        properties:
-                          backends:
-                            items:
-                              properties:
-                                name:
-                                  type: string
-                                path:
-                                  type: string
-                                pathType:
-                                  type: string
-                              type: object
-                            type: array
-                          host:
-                            type: string
-                        type: object
-                      type: array
-                    tls:
-                      items:
-                        properties:
-                          hosts:
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          secretName:
-                            type: string
-                        type: object
-                      type: array
-                  type: object
                 initializer:
                   properties:
                     image:
@@ -27618,6 +27661,31 @@ spec:
                               type: object
                             loadBalancerClass:
                               type: string
+                            ports:
+                              items:
+                                properties:
+                                  appProtocol:
+                                    type: string
+                                  name:
+                                    type: string
+                                  nodePort:
+                                    format: int32
+                                    type: integer
+                                  port:
+                                    format: int32
+                                    type: integer
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                  targetPort:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              type: array
                             type:
                               type: string
                           type: object

--- a/charts/greptimedb-operator/templates/crds/crd-greptimedbstandalone.yaml
+++ b/charts/greptimedb-operator/templates/crds/crd-greptimedbstandalone.yaml
@@ -3602,6 +3602,31 @@ spec:
                       type: object
                     loadBalancerClass:
                       type: string
+                    ports:
+                      items:
+                        properties:
+                          appProtocol:
+                            type: string
+                          name:
+                            type: string
+                          nodePort:
+                            format: int32
+                            type: integer
+                          port:
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            type: string
+                          targetPort:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                        required:
+                          - port
+                        type: object
+                      type: array
                     type:
                       type: string
                   type: object

--- a/charts/greptimedb-operator/values.yaml
+++ b/charts/greptimedb-operator/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- The image pull policy for the controller
   imagePullPolicy: IfNotPresent
   # -- The image tag
-  tag: v0.6.0
+  tag: v0.6.1
   # -- The image pull secrets
   pullSecrets: []
 


### PR DESCRIPTION
Related to: https://github.com/GreptimeTeam/greptimedb-operator/releases/tag/v0.6.1

                                                                                                                                       
   ## Summary                                                                                                                                              
                                                                                                                                                           
   This PR updates the GreptimeDB operator to **v0.6.1** and removes the deprecated ingress configuration from the `greptimedb-cluster` chart.             
                                                                                                                                                           
   ## Changes                                                                                                                                              
                                                                                                                                                           
   ### greptimedb-operator                                                                                                                                 
                                                                                                                                                           
   - Bump operator image and `appVersion` from `v0.6.0` to `v0.6.1`.                                                                                       
   - Bump chart version from `0.6.1` to `0.6.2`.                                                                                                           
   - Sync CRDs with operator v0.6.1:                                                                                                                       
     - Add `auditLog` support to `frontend` and `frontendGroups`.                                                                                          
     - Add `ports` field to the service configuration for `GreptimeDBCluster` and `GreptimeDBStandalone`.                                                  
     - Remove the `ingress` field from the `GreptimeDBCluster` CRD.                                                                                        
   - Remove `networking.k8s.io/ingresses` permissions from the operator `ClusterRole`.                                                                     
                                                                                                                                                           
   ### greptimedb-cluster                                                                                                                                  
                                                                                                                                                           
   - Bump chart version from `0.8.30` to `0.8.31`.                                                                                                         
   - Bump the initializer image tag from `v0.6.0` to `v0.6.1`.                                                                                             
   - Remove ingress support:                                                                                                                               
     - Drop the `ingress` section from `templates/cluster.yaml`.                                                                                           
     - Drop the `ingress` block from `values.yaml`.                                                                                                        
                                                                                                                                                           
   ## Motivation                                                                                                                                           
                                                                                                                                                           
   Ingress is no longer supported in operator v0.6.1, so the corresponding configuration and RBAC permissions are removed to stay in sync with the upstream operator.                                                                                                                                        
                                                                                                                                                                                                                                                                                                       
                                                                                                                                                          
