### PR TITLE
chore: update greptimedb-cluster to v1.2.0

### DIFF
--- a/charts/greptimedb-cluster/Chart.yaml
+++ b/charts/greptimedb-cluster/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: greptimedb-cluster
 description: A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 type: application
-version: 0.8.34
-appVersion: 1.2.0-beta.2
+version: 0.8.35
+appVersion: 1.2.0
 home: https://github.com/GreptimeTeam/greptimedb
 sources:
   - https://github.com/GreptimeTeam/greptimedb

--- a/charts/greptimedb-cluster/README.md
+++ b/charts/greptimedb-cluster/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying GreptimeDB cluster in Kubernetes.
 
-![Version: 0.8.34](https://img.shields.io/badge/Version-0.8.34-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0-beta.2](https://img.shields.io/badge/AppVersion-1.2.0--beta.2-informational?style=flat-square)
+![Version: 0.8.35](https://img.shields.io/badge/Version-0.8.35-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 ## Source Code
 
@@ -365,7 +365,7 @@ helm uninstall mycluster -n default
 | image.pullSecrets | list | `[]` | The image pull secrets |
 | image.registry | string | `"docker.io"` | The image registry |
 | image.repository | string | `"greptime/greptimedb"` | The image repository |
-| image.tag | string | `"v1.2.0-beta.2"` | The image tag |
+| image.tag | string | `"v1.2.0"` | The image tag |
 | initializer.registry | string | `"docker.io"` | Initializer image registry |
 | initializer.repository | string | `"greptime/greptimedb-initializer"` | Initializer image repository |
 | initializer.tag | string | `"v0.6.1"` | Initializer image tag |

--- a/charts/greptimedb-cluster/values.yaml
+++ b/charts/greptimedb-cluster/values.yaml
@@ -4,7 +4,7 @@ image:
   # -- The image repository
   repository: greptime/greptimedb
   # -- The image tag
-  tag: "v1.2.0-beta.2"
+  tag: "v1.2.0"
   # -- The image pull secrets
   pullSecrets: []
 


### PR DESCRIPTION
## What changed

Update only the `greptimedb-cluster` chart for GreptimeDB v1.2.0:
- Chart version: `0.8.34` → `0.8.35`.
- `appVersion`: `1.2.0-beta.2` → `1.2.0`.
- Default image tag: `v1.2.0-beta.2` → `v1.2.0`.
- Regenerate README with the repository's helm-docs v1.12.0 generator.

The cluster and standalone bumps are separate PRs following CONTRIBUTING.md's one-chart-per-PR guidance. No chart templates, CRDs, or other chart versions are changed.

## Verification

- `git diff --check`: passed.
- `make check-docs`: passed on the committed tree (GOPATH/GOBIN/GOCACHE located on NVMe).
- `helm lint`: passed.
- `helm template`: passed; rendered image is `docker.io/greptime/greptimedb:v1.2.0`.
- Cluster rendering uses a source-identical temporary chart copy with dependencies downloaded; no dependency lock/source changes are included.
- `helm unittest`, `ct lint`, and kind/e2e deployment were not run locally. CI still needs to validate these.

The existing version updater could not execute in the local environment because `yq` was absent; only its exact version fields were updated, then README generation and consistency checks were run normally.

## Release state

This is the manually prepared downstream update. Published v1.2.0 artifacts are verified, but GitHub still marks the release as Pre-release. Creating this PR does not merge, deploy, publish a chart, or promote the GitHub release. Merging this PR will trigger the chart repository's release workflow.

Release: https://github.com/GreptimeTeam/greptimedb/releases/tag/v1.2.0
Tracking: https://github.com/GreptimeTeam/greptimedb/issues/9015
